### PR TITLE
CtnrViewTests - Cannot set values on m2m field with intermediary model

### DIFF
--- a/cyder/core/ctnr/forms.py
+++ b/cyder/core/ctnr/forms.py
@@ -7,7 +7,7 @@ from cyder.core.ctnr.models import Ctnr, CtnrUser
 class CtnrForm(forms.ModelForm):
     class Meta:
         model = Ctnr
-
+        exclude = ('users',)
 
 class CtnrUserForm(forms.ModelForm):
     level = forms.ChoiceField(widget=forms.RadioSelect,


### PR DESCRIPTION
Removing users fixes the issue. After editing/creating a ctnr the page needs to redirect to the add users to ctnr form.
