### PR TITLE
Fix paginator "First" button

### DIFF
--- a/cyder/base/templates/base/includes/pagination.html
+++ b/cyder/base/templates/base/includes/pagination.html
@@ -7,7 +7,7 @@
 
   <div class="pagination">
     <ul>
-        <li><a href="?{{ page_name}}=1">First</a></li>
+        <li><a href="{{ page_url|urlparams(**{page_name: 1}) }}">First</a></li>
       {% if page_obj.has_previous() %}
       <li><a href="{{ page_url|urlparams(**{page_name: page_obj.previous_page_number()}) }}">Prev</a></li>
       {% else %}


### PR DESCRIPTION
Don't remove the current query string, just change the page. (This is how
the other paginator buttons currently work.)
