### PR TITLE
Range usage now produces a proper count of total ips.

### DIFF
--- a/cyder/cydhcp/range/range_usage.py
+++ b/cyder/cydhcp/range/range_usage.py
@@ -58,7 +58,7 @@ def range_usage(start, end, ip_type):
         StaticInterface.objects.filter(ipf_q)),
         key=record_ip)
     contiguous_ip_list, total_used = contiguous_ips(taken_ips)
-    total_ips = end - start
+    total_ips = (end - start) + 1
     range_usage_list = []
     free_range_start = ip_start
     for filled_range in contiguous_ip_list:


### PR DESCRIPTION
Error mentioned in https://github.com/OSU-Net/cyder/issues/125
This should produce proper counting of total ip's. Previously a.b.c.10 - a.b.c.20 would produce 10 as a total. Either not counting 10 or 20 itself. 
