### PR TITLE
Ignore dirty vendor directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "vendor"]
 	path = vendor
 	url = git@github.com:mozilla/playdoh-lib
+	ignore = dirty
 [submodule "vendor-local/src/iscpy"]
 	path = vendor-local/src/iscpy
 	url = https://github.com/uberj/iscpy


### PR DESCRIPTION
Under most circumstances, this pull request eliminates

```
#   modified:   vendor (modified content)
```

in the output of `git status` and

```
-Subproject commit 6afe43df27d38fc561f49ff4bd96a8d2bf5da33f
+Subproject commit 6afe43df27d38fc561f49ff4bd96a8d2bf5da33f-dirty
```

in `git diff`. It still allows you to see those if you want—you just have to cd to the vendor directory first.
