### PR TITLE
change playdoh submodule to use read-only url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor"]
 	path = vendor
-	url = git@github.com:mozilla/playdoh-lib
+	url = https://github.com/mozilla/playdoh-lib.git
 	ignore = dirty
 [submodule "vendor-local/src/iscpy"]
 	path = vendor-local/src/iscpy


### PR DESCRIPTION
as the title says.  allows cloning without the need for an authorized ssh key.
