### PR TITLE
Fixed ctnr field not being autopopulated in staticinterfaceform

### DIFF
--- a/cyder/cydhcp/interface/static_intr/forms.py
+++ b/cyder/cydhcp/interface/static_intr/forms.py
@@ -38,7 +38,8 @@ class StaticInterfaceForm(forms.ModelForm, UsabilityFormMixin):
         super(StaticInterfaceForm, self).__init__(*args, **kwargs)
         self.fields.keyOrder = ['system', 'description', 'label', 'ip_str',
                                 'ip_type', 'ttl', 'workgroup', 'mac', 'vrf',
-                                'domain', 'dhcp_enabled', 'dns_enabled']
+                                'domain', 'dhcp_enabled', 'dns_enabled',
+                                'ctnr']
 
     class Meta:
         model = StaticInterface


### PR DESCRIPTION
Fixed ctnr field not being autopopulated in staticinterfaceform, my form was not as prepared for the model change as I thought it was. This works.
