### PR TITLE
Simplify StaticInterface.system and DynamicInterface.system by using Django's built-in required field functionality

### DIFF
--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -86,11 +86,6 @@ class DynamicInterface(models.Model, ObjectUrlMixin):
             self.mac = self.mac.lower()
             validate_mac(self.mac)
 
-        if not self.system:
-            raise ValidationError(
-                "An interface means nothing without its system."
-            )
-
         super(DynamicInterface, self).clean()
 
 

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -223,11 +223,6 @@ class StaticInterface(BaseAddressRecord, BasePTR):
             self.mac = self.mac.lower()
             validate_mac(self.mac)
 
-        if not self.system:
-            raise ValidationError(
-                "An interface means nothing without its system."
-            )
-
         from cyder.cydns.ptr.models import PTR
         if PTR.objects.filter(ip_str=self.ip_str, name=self.fqdn).exists():
             raise ValidationError('A PTR already uses this Name and IP')


### PR DESCRIPTION
This requires no south or Maintain migrations. It just removes some unneeded cleaning because Django already knows how to enforce field requiredness.
