### PR TITLE
Vrfs and Workgroups are no longer required for dynamic interfaces

### DIFF
--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -17,14 +17,14 @@ import datetime
 
 class DynamicInterface(models.Model, ObjectUrlMixin):
     ctnr = models.ForeignKey(Ctnr, null=False)
-    workgroup = models.ForeignKey(Workgroup, null=True)
+    workgroup = models.ForeignKey(Workgroup, null=True, blank=True)
     system = models.ForeignKey(System,
                                null=True,
                                blank=True,
                                help_text="System to associate "
                                          "the interface with")
     mac = models.CharField(max_length=19, blank=True)
-    vrf = models.ForeignKey(Vrf, null=True)
+    vrf = models.ForeignKey(Vrf, null=True, blank=True)
     domain = models.ForeignKey(Domain, null=True)
     range = models.ForeignKey(Range, null=False)
     dhcp_enabled = models.BooleanField(default=True)


### PR DESCRIPTION
As mentioned in https://github.com/OSU-Net/cyder/issues/231
