### PR TITLE
Removed network wizard from cydhcp sidebar

### DIFF
--- a/cyder/cydhcp/templates/cydhcp/includes/cydhcp_sidebar.html
+++ b/cyder/cydhcp/templates/cydhcp/includes/cydhcp_sidebar.html
@@ -4,7 +4,6 @@
 {{ render_sidebar(request, [
   ('site', 'Site'),
   ('network', 'Network'),
-  ('network-wizard', 'Network Wizard'),
   ('range', 'Range'),
   ('vlan', 'VLAN'),
   ('vrf', 'VRF'),


### PR DESCRIPTION
As mentioned in https://github.com/OSU-Net/cyder/issues/251
