### PR TITLE
tablefy (reluctantly) takes lists too

### DIFF
--- a/cyder/base/utils.py
+++ b/cyder/base/utils.py
@@ -77,7 +77,7 @@ def tablefy(objects, users=False, extra_cols=None, info=True):
             headers.append([col['header'], col['sort_field']])
 
     foreign_keys = [j for _, j in headers if j]
-    if isinstance(objects, Page):
+    if isinstance(objects, Page) and type(objects.object_list) is not list:
         objects.object_list = objects.object_list.select_related(*foreign_keys)
     elif isinstance(objects, query.QuerySet):
         objects = objects.select_related(*foreign_keys)


### PR DESCRIPTION
Fix for network detail views that have child networks or parent networks, like mentioned in https://github.com/OSU-Net/cyder/issues/262.
