### PR TITLE
User detail view patch

### DIFF
--- a/cyder/core/cyuser/templates/cyuser/user_detail.html
+++ b/cyder/core/cyuser/templates/cyuser/user_detail.html
@@ -1,17 +1,17 @@
 {% extends "core/core_detail.html" %}
 {% from "base/tables.html" import render_table %}
 
-{% block title %} User  {{ user.username }} {% endblock %}
-{% block header %} User {{ user.username }} {% endblock %}
+{% block title %} User  {{ obj.user.username }} {% endblock %}
+{% block header %} User {{ obj.user.username }} {% endblock %}
 
 {% block action_bar %}
-  {% if request.user.is_superuser and request.user.username != user.username %}
+  {% if request.user.is_superuser and request.user.username != obj.user.username %}
     <a class="btn btn-primary" href="{{ url('become-user',
-                                            username=user.username) }}">
+                                            username=obj.user.username) }}">
       Become User
     </a>
   {% else %}
-    {% if request.session.become_user_stack and request.user.username == user.username %}
+    {% if request.session.become_user_stack and request.user.username == obj.user.username %}
       <a class="btn btn-primary" href="{{ url('unbecome-user') }}">
       Unbecome User
       </a>


### PR DESCRIPTION
Fixed title, become and unbecome user buttons not being created in user detail view. This is a patch to the user detail view pull request where I switched user detail to use cy_view.
