### PR TITLE
Permissions for keyvalues now default to their respective object's permissions

### DIFF
--- a/cyder/core/cyuser/backends.py
+++ b/cyder/core/cyuser/backends.py
@@ -91,12 +91,12 @@ def _has_perm(user, ctnr, action, obj=None, obj_class=None):
     if obj:
         obj_type = obj.__class__.__name__
     elif obj_class:
-        if 'KeyValue' in obj_class.__name__:
-            obj_type = obj_class.__name__.split('KeyValue')[0]
-        else:
-            obj_type = obj_class.__name__
+        obj_type = obj_class.__name__
     else:
         return False
+
+    if obj_type and 'KeyValue' in obj_type:
+        obj_type = obj_type.split('KeyValue')[0]
 
     handling_function = {
         # Administrative.


### PR DESCRIPTION
Designed to resolve https://github.com/OSU-Net/cyder/issues/257
