### PR TITLE
Vrf.get_related_networks() hotfix

### DIFF
--- a/cyder/cydhcp/vrf/models.py
+++ b/cyder/cydhcp/vrf/models.py
@@ -44,7 +44,7 @@ class Vrf(models.Model, ObjectUrlMixin):
     def get_related_networks(self, vrfs):
         networks = set()
         for vrf in vrfs:
-            for network in vrf.network_set:
+            for network in vrf.network_set.all():
                 networks.update(network.get_related_networks())
         return networks
 


### PR DESCRIPTION
In my haste to get #277 ready, I forgot how reverse relationships work. This pull request fixes a mistake I made in `Vrf.get_related_networks`.

Sorry for allowing broken code to be merged into master.
