### PR TITLE
Plebs can now switch to global container

### DIFF
--- a/cyder/core/ctnr/views.py
+++ b/cyder/core/ctnr/views.py
@@ -370,9 +370,9 @@ def change_ctnr(request, pk=None):
     except CtnrUser.DoesNotExist:
         ctnr_user = None
 
-    if ctnr_user or global_ctnr_user:
+    prev = request.session['ctnr']
+    if ctnr_user or global_ctnr_user or ctnr.pk == 1:
         # Set session ctnr and level.
-        prev = request.session['ctnr']
         request.session['ctnr'] = ctnr
 
         # Higher level overrides.


### PR DESCRIPTION
I was testing a user without permissions (a "pleb") in the global container, and found that they could not access the global container due to a bug. All users should be able to access the global container, since it is our "read-only access" container.
