### PR TITLE
Force maintain_sb connection to use UTF-8

### DIFF
--- a/cyder/migration/management/commands/dhcp_migrate.py
+++ b/cyder/migration/management/commands/dhcp_migrate.py
@@ -300,13 +300,6 @@ def migrate_dynamic_hosts():
             if not value or value == '0':
                 continue
 
-            try:
-                value.encode('utf-8')
-            except UnicodeDecodeError:
-                print "Encode error (%s: %s)..." % (key, value),
-                value = value.decode('cp1252')
-                print "re-encoding as %s" % value
-
             kv = SystemKeyValue(system=s, key=sys_value_keys[key],
                                 value=value)
             kv.clean()

--- a/cyder/migration/management/commands/dns_migrate.py
+++ b/cyder/migration/management/commands/dns_migrate.py
@@ -180,7 +180,7 @@ class Zone(object):
                 if not value or value == '0':
                     continue
                 kv = SystemKeyValue(system=system, key=sys_value_keys[key],
-                                    value=str(value))
+                                    value=value)
                 kv.clean()
                 kv.save()
 


### PR DESCRIPTION
Currently we allow MySQLdb (our Python MySQL client) to initiate connections using its own default encoding, which on my computer is `'utf8'` but on some other devs' computers and on the server at cyder.nws.o.e is `'latin-1'`. We haven't discovered the reason for this discrepancy, so the best solution at the moment is to force the character set to be `'utf8'`. With UTF-8, I don't believe we have to do any encoding or decoding, since text-like data is returned by MySQLdb as Python unicode strings.
