### PR TITLE
Updating an object may give it a new container

### DIFF
--- a/cyder/base/views.py
+++ b/cyder/base/views.py
@@ -153,7 +153,7 @@ def cy_view(request, get_klasses_fn, template, pk=None, obj_type=None):
                         request = ctnr_update_session(request, obj)
 
                     if (hasattr(obj, 'ctnr_set') and
-                            len(obj.ctnr_set.all()) == 0):
+                            not obj.ctnr_set.all().exists()):
                         obj.ctnr_set.add(request.session['ctnr'])
 
                     return redirect(

--- a/cyder/cydns/views.py
+++ b/cyder/cydns/views.py
@@ -96,7 +96,7 @@ def cydns_view(request, pk=None):
                     return redirect(request.META.get('HTTP_REFERER', ''))
 
                 if (hasattr(record, 'ctnr_set') and
-                        len(record.ctnr_set.all()) == 0):
+                        not record.ctnr_set.all().exists()):
                     record.ctnr_set.add(request.session['ctnr'])
                     return redirect(record.get_list_url())
 


### PR DESCRIPTION
When creating a range, domain, or workgroup the users current container is automatically added to the object, when updating it is not.

Designed to resolve https://github.com/OSU-Net/cyder/issues/273
