### PR TITLE
range detail no longer breaks when a ptr is being displayed in its usage

### DIFF
--- a/cyder/cydhcp/range/templates/range/range_detail.html
+++ b/cyder/cydhcp/range/templates/range/range_detail.html
@@ -95,9 +95,15 @@
                   <td>{{ record_ip }}</td>
                   <td>{{ record._meta.db_table|prettify_obj_type }}</td>
                   {% if record.get_detail_url() %}
-                    <td><a href="{{ record.get_detail_url() }}">{{record.fqdn}}</a></td>
+                    <td><a href="{{ record.get_detail_url() }}">{{record}}</a></td>
                   {% else %}
-                    <td><a href="{{ record.domain.get_detail_url() }}">{{record.fqdn}}</a></td>
+                    {% if record.domain %}
+                      <td><a href="{{ record.domain.get_detail_url() }}">{{record}}</a></td>
+                    {% elif record.reverse_domain %}
+                      <td><a href="{{ record.reverse_domain.get_detail_url() }}">{{record}}</a></td>
+                    {% else %}
+                      <td>{{record}}</td>
+                    {% endif %}
                   {% endif %}
                 </tr>
               {% endfor %}


### PR DESCRIPTION
Designed to resolve https://github.com/OSU-Net/cyder/issues/359
