### PR TITLE
Make maintain_migrate print a helpful error message if no flags are passed.

### DIFF
--- a/cyder/migration/management/commands/maintain_migrate.py
+++ b/cyder/migration/management/commands/maintain_migrate.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 from cyder.cydns.cybind.builder import DNSBuilder, BuildError
@@ -130,3 +130,9 @@ class Command(BaseCommand):
 
         if options['dhcp']:
             dhcp_migrate.do_everything(skip=False)
+
+        del options['verbosity']
+        del options['settings']
+        if not any(options.values()):
+            raise CommandError("No flags passed; no action taken. "
+                               "Try maintain_migrate --help")


### PR DESCRIPTION
I'm probably the only one who even cares about this, but it annoyed me so I fixed it. Previously, if you did `./manage.py maintain_migrate`, it would do nothing. Now it will print a bright red error message pointing you in the right direction.
