### PR TITLE
Vlan's now display their number in dropdowns

### DIFF
--- a/cyder/cydhcp/vlan/models.py
+++ b/cyder/cydhcp/vlan/models.py
@@ -22,7 +22,7 @@ class Vlan(models.Model, ObjectUrlMixin):
         unique_together = ("name", "number")
 
     def __str__(self):
-        return get_display(self)
+        return get_display(self) + ', {0}'.format(self.number)
 
     def __repr__(self):
         return "<Vlan {0}>".format(str(self))


### PR DESCRIPTION
Designed to resolve https://github.com/OSU-Net/cyder/issues/330
One issue, in the vlan tables we have redundant data with the numbers.
