### PR TITLE
Modify api tests to use django TestCase

### DIFF
--- a/cyder/api/v1/endpoints/core/ctnr/tests.py
+++ b/cyder/api/v1/endpoints/core/ctnr/tests.py
@@ -1,7 +1,6 @@
 import json
 from django.contrib.auth.models import User
 
-from cyder.api.v1.endpoints.core.tests import CoreAPITests
 from cyder.core.ctnr.models import Ctnr, CtnrUser
 from cyder.cydhcp.range.models import Range
 from cyder.cydhcp.workgroup.models import Workgroup
@@ -10,13 +9,15 @@ from cyder.cydhcp.network.models import Network
 from cyder.cydhcp.vlan.models import Vlan
 from cyder.cydhcp.vrf.models import Vrf
 from cyder.cydns.domain.models import Domain
+from cyder.api.v1.tests.base import APITests
 
 
-class CtnrAPI_Test(CoreAPITests):
+class CtnrAPI_Test(APITests):
+    __test__ = True
     model = Ctnr
 
-    def __init__(self):
-        super(CoreAPITests, self).__init__()
+    def setUp(self):
+        super(CtnrAPI_Test, self).setUp()
         user_data = {
             'username': 'testuser',
         }

--- a/cyder/api/v1/endpoints/core/system/tests.py
+++ b/cyder/api/v1/endpoints/core/system/tests.py
@@ -1,9 +1,9 @@
-from cyder.api.v1.endpoints.core.tests import CoreAPITests
-from cyder.api.v1.tests.base import APIKVTestMixin
+from cyder.api.v1.tests.base import APIKVTestMixin, APITests
 from cyder.core.system.models import System
 
 
-class SystemAPI_Test(CoreAPITests, APIKVTestMixin):
+class SystemAPI_Test(APITests, APIKVTestMixin):
+    __test__ = True
     model = System
     keyvalue_attr = "systemkeyvalue_set"
 

--- a/cyder/api/v1/endpoints/core/tests.py
+++ b/cyder/api/v1/endpoints/core/tests.py
@@ -1,5 +1,0 @@
-from cyder.api.v1.tests.base import APITests
-
-
-class CoreAPITests(APITests):
-    root = 'core'

--- a/cyder/api/v1/endpoints/core/user/tests.py
+++ b/cyder/api/v1/endpoints/core/user/tests.py
@@ -1,10 +1,11 @@
 from django.contrib.auth.models import User
+from cyder.api.v1.tests.base import APITests
 
-from cyder.api.v1.endpoints.core.tests import CoreAPITests
 
-
-class UserAPI_Test(CoreAPITests):
+class UserAPI_Test(APITests):
+    __test__ = True
     model = User
+    url = "core/user"
 
     def create_data(self):
-        return self.model.objects.get_or_create(username='test_user')[0]
+        return self.model.objects.get_or_create(username="test_user")[0]

--- a/cyder/api/v1/endpoints/dhcp/dynamic_interface/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/dynamic_interface/tests.py
@@ -1,21 +1,20 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.core.ctnr.models import Ctnr
 from cyder.core.system.models import System
 from cyder.cydhcp.interface.dynamic_intr.models import DynamicInterface
 from cyder.cydhcp.range.models import Range
 from cyder.cydns.domain.models import Domain
+from cyder.api.v1.tests.base import APITests
 
 
-class DynamicInterfaceBase(DHCPAPITests):
+class DynamicInterfaceBase(APITests):
     model = DynamicInterface
-    urlname = "dynamic_interface"
     keyvalue_attr = "dynamicintrkeyvalue_set"
 
-    def __init__(self, *args, **kwargs):
+    def setUp(self):
         Domain.objects.get_or_create(name='arpa')
         self.ctnr, _ = Ctnr.objects.get_or_create(name="TestCtnr")
         self.system, _ = System.objects.get_or_create(name="TestSystem")
-        super(DynamicInterfaceBase, self).__init__(self, *args, **kwargs)
+        super(DynamicInterfaceBase, self).setUp()
 
     def create_data(self):
         data = {
@@ -28,16 +27,20 @@ class DynamicInterfaceBase(DHCPAPITests):
 
 
 class DynamicInterfaceV4API_Test(DynamicInterfaceBase):
-    def __init__(self, *args, **kwargs):
-        super(DynamicInterfaceV4API_Test, self).__init__(self, *args, **kwargs)
+    __test__ = True
+
+    def setUp(self):
+        super(DynamicInterfaceV4API_Test, self).setUp()
         self.range, _ = Range.objects.get_or_create(
             start_str="12.12.0.0", end_str="12.12.255.255",
             is_reserved=True)
 
 
 class DynamicInterfaceV6API_Test(DynamicInterfaceBase):
-    def __init__(self, *args, **kwargs):
-        super(DynamicInterfaceV6API_Test, self).__init__(self, *args, **kwargs)
+    __test__ = True
+
+    def setUp(self):
+        super(DynamicInterfaceV6API_Test, self).setUp()
         self.range, _ = Range.objects.get_or_create(
             start_str="2001:0db8:0000:0000:0000:0000:0000:0000",
             end_str="2001:0db8:0000:0000:0000:0000:0000:0001",

--- a/cyder/api/v1/endpoints/dhcp/network/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/network/tests.py
@@ -1,18 +1,18 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.site.models import Site
 from cyder.cydhcp.network.models import Network
 from cyder.cydhcp.vlan.models import Vlan
 from cyder.cydhcp.vrf.models import Vrf
+from cyder.api.v1.tests.base import APITests
 
 
-class NetworkBase(DHCPAPITests):
+class NetworkBase(APITests):
     model = Network
 
-    def __init__(self, *args, **kwargs):
+    def setUp(self):
         self.site = Site.objects.get_or_create(name='site')[0]
         self.vlan = Vlan.objects.get_or_create(name='vlan', number=420)[0]
         self.vrf = Vrf.objects.get_or_create(name='vrf')[0]
-        super(NetworkBase, self).__init__(*args, **kwargs)
+        super(NetworkBase, self).setUp()
 
     def create_data(self):
         return {
@@ -23,6 +23,8 @@ class NetworkBase(DHCPAPITests):
 
 
 class NetworkV4API_Test(NetworkBase):
+    __test__ = True
+
     def create_data(self):
         data = super(NetworkV4API_Test, self).create_data()
         data.update({
@@ -33,6 +35,8 @@ class NetworkV4API_Test(NetworkBase):
 
 
 class NetworkV6API_Test(NetworkBase):
+    __test__ = True
+
     def create_data(self):
         data = super(NetworkV6API_Test, self).create_data()
         data.update({

--- a/cyder/api/v1/endpoints/dhcp/range/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/range/tests.py
@@ -1,16 +1,16 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.range.models import Range
 from cyder.cydhcp.site.models import Site
 from cyder.cydhcp.network.models import Network
 from cyder.cydhcp.vlan.models import Vlan
 from cyder.cydhcp.vrf.models import Vrf
+from cyder.api.v1.tests.base import APITests
 
 
-class RangeBase(DHCPAPITests):
+class RangeBase(APITests):
     model = Range
 
-    def __init__(self, *args, **kwargs):
-        super(RangeBase, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(RangeBase, self).setUp()
         self.site = Site.objects.get_or_create(name='site')[0]
         self.vlan = Vlan.objects.get_or_create(name='vlan', number=420)[0]
         self.vrf = Vrf.objects.get_or_create(name='vrf')[0]
@@ -23,6 +23,8 @@ class RangeBase(DHCPAPITests):
 
 
 class RangeV4API_Test(RangeBase):
+    __test__ = True
+
     def create_data(self):
         self.network_data.update({
             'ip_type': '4',
@@ -41,6 +43,8 @@ class RangeV4API_Test(RangeBase):
 
 
 class RangeV6API_Test(RangeBase):
+    __test__ = True
+
     def create_data(self):
         self.network_data.update({
             'ip_type': '6',

--- a/cyder/api/v1/endpoints/dhcp/site/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/site/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.site.models import Site
+from cyder.api.v1.tests.base import APITests
 
 
-class SiteAPI_Test(DHCPAPITests):
+class SiteAPI_Test(APITests):
+    __test__ = True
     model = Site
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dhcp/static_interface/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/static_interface/tests.py
@@ -1,20 +1,19 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.core.ctnr.models import Ctnr
 from cyder.core.system.models import System
 from cyder.cydhcp.interface.static_intr.models import StaticInterface
 from cyder.cydns.domain.models import Domain
+from cyder.api.v1.tests.base import APITests
 
 
-class StaticInterfaceBase(DHCPAPITests):
+class StaticInterfaceBase(APITests):
     model = StaticInterface
-    urlname = "static_interface"
     keyvalue_attr = "staticintrkeyvalue_set"
 
-    def __init__(self, *args, **kwargs):
+    def setUp(self):
         Domain.objects.get_or_create(name='arpa')
         self.ctnr, _ = Ctnr.objects.get_or_create(name="TestCtnr")
         self.system, _ = System.objects.get_or_create(name="TestSystem")
-        super(StaticInterfaceBase, self).__init__(self, *args, **kwargs)
+        super(StaticInterfaceBase, self).setUp()
 
     def create_data(self):
         return {
@@ -31,8 +30,10 @@ class StaticInterfaceBase(DHCPAPITests):
 
 
 class StaticInterfaceV4API_Test(StaticInterfaceBase):
-    def __init__(self, *args, **kwargs):
-        super(StaticInterfaceV4API_Test, self).__init__(self, *args, **kwargs)
+    __test__ = True
+
+    def setUp(self):
+        super(StaticInterfaceV4API_Test, self).setUp()
         Domain.objects.get_or_create(name='in-addr.arpa')
         Domain.objects.get_or_create(name='11.in-addr.arpa')
 
@@ -51,8 +52,10 @@ class StaticInterfaceV4API_Test(StaticInterfaceBase):
 
 
 class StaticInterfaceV6API_Test(StaticInterfaceBase):
-    def __init__(self, *args, **kwargs):
-        super(StaticInterfaceV6API_Test, self).__init__(self, *args, **kwargs)
+    __test__ = True
+
+    def setUp(self):
+        super(StaticInterfaceV6API_Test, self).setUp()
         Domain.objects.get_or_create(name='ip6.arpa')
         Domain.objects.get_or_create(name='2.ip6.arpa')
 

--- a/cyder/api/v1/endpoints/dhcp/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/tests.py
@@ -1,9 +1,0 @@
-from cyder.api.v1.tests.base import APITests, APIKVTestMixin
-
-
-class DHCPAPITests(APITests, APIKVTestMixin):
-    root = 'dhcp'
-
-    def __init__(self, *args, **kwargs):
-        super(DHCPAPITests, self).__init__(self, *args, **kwargs)
-        super(APITests, self).__init__(self, *args, **kwargs)

--- a/cyder/api/v1/endpoints/dhcp/vlan/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/vlan/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.vlan.models import Vlan
+from cyder.api.v1.tests.base import APITests
 
 
-class VlanAPI_Test(DHCPAPITests):
+class VlanAPI_Test(APITests):
+    __test__ = True
     model = Vlan
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dhcp/vrf/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/vrf/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.vrf.models import Vrf
+from cyder.api.v1.tests.base import APITests
 
 
-class VrfAPI_Test(DHCPAPITests):
+class VrfAPI_Test(APITests):
+    __test__ = True
     model = Vrf
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dhcp/workgroup/tests.py
+++ b/cyder/api/v1/endpoints/dhcp/workgroup/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dhcp.tests import DHCPAPITests
 from cyder.cydhcp.workgroup.models import Workgroup
+from cyder.api.v1.tests.base import APITests
 
 
-class WorkgroupAPI_Test(DHCPAPITests):
+class WorkgroupAPI_Test(APITests):
+    __test__ = True
     model = Workgroup
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/address_record/tests.py
+++ b/cyder/api/v1/endpoints/dns/address_record/tests.py
@@ -1,11 +1,10 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.address_record.models import AddressRecord
+from cyder.api.v1.tests.base import APITests
 
 
-class AddressRecordBase(DNSAPITests):
+class AddressRecordBase(APITests):
     model = AddressRecord
     root = "dns"
-    urlname = "address_record"
 
     def create_data(self, label):
         return {
@@ -17,6 +16,8 @@ class AddressRecordBase(DNSAPITests):
 
 
 class AddressRecordv4API_Test(AddressRecordBase):
+    __test__ = True
+
     def create_data(self):
         data = super(AddressRecordv4API_Test, self).create_data('foo')
         data.update({
@@ -29,7 +30,7 @@ class AddressRecordv4API_Test(AddressRecordBase):
 
 
 class AddressRecordv6API_Test(AddressRecordBase):
-    model = AddressRecord
+    __test__ = True
 
     def create_data(self):
         data = super(AddressRecordv6API_Test, self).create_data('bar')

--- a/cyder/api/v1/endpoints/dns/cname/tests.py
+++ b/cyder/api/v1/endpoints/dns/cname/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.cname.models import CNAME
+from cyder.api.v1.tests.base import APITests
 
 
-class CNAMEAPI_Test(DNSAPITests):
+class CNAMEAPI_Test(APITests):
+    __test__ = True
     model = CNAME
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/domain/tests.py
+++ b/cyder/api/v1/endpoints/dns/domain/tests.py
@@ -1,10 +1,11 @@
+from cyder.cydns.domain.models import Domain
+from cyder.api.v1.tests.base import APITests
+
 import json
 
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
-from cyder.cydns.domain.models import Domain
 
-
-class DomainAPI_Test(DNSAPITests):
+class DomainAPI_Test(APITests):
+    __test__ = True
     model = Domain
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/mx/tests.py
+++ b/cyder/api/v1/endpoints/dns/mx/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.mx.models import MX
+from cyder.api.v1.tests.base import APITests
 
 
-class MXAPI_Test(DNSAPITests):
+class MXAPI_Test(APITests):
+    __test__ = True
     model = MX
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/nameserver/tests.py
+++ b/cyder/api/v1/endpoints/dns/nameserver/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.nameserver.models import Nameserver
+from cyder.api.v1.tests.base import APITests
 
 
-class NameserverAPI_Test(DNSAPITests):
+class NameserverAPI_Test(APITests):
+    __test__ = True
     model = Nameserver
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/ptr/tests.py
+++ b/cyder/api/v1/endpoints/dns/ptr/tests.py
@@ -1,9 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.domain.models import Domain
 from cyder.cydns.ptr.models import PTR
+from cyder.api.v1.tests.base import APITests
 
 
-class PTRBase(DNSAPITests):
+class PTRBase(APITests):
     model = PTR
 
     def create_data(self):
@@ -18,7 +18,7 @@ class PTRBase(DNSAPITests):
 
 
 class PTRv4API_Test(PTRBase):
-    model = PTR
+    __test__ = True
 
     def create_data(self):
         data = super(PTRv4API_Test, self).create_data()
@@ -35,7 +35,7 @@ class PTRv4API_Test(PTRBase):
 
 
 class PTRv6API_Test(PTRBase):
-    model = PTR
+    __test__ = True
 
     def create_data(self):
         data = super(PTRv6API_Test, self).create_data()

--- a/cyder/api/v1/endpoints/dns/soa/tests.py
+++ b/cyder/api/v1/endpoints/dns/soa/tests.py
@@ -1,9 +1,10 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.api.v1.tests.base import APIKVTestMixin
 from cyder.cydns.soa.models import SOA
+from cyder.api.v1.tests.base import APITests
 
 
-class SOAAPI_Test(DNSAPITests, APIKVTestMixin):
+class SOAAPI_Test(APITests, APIKVTestMixin):
+    __test__ = True
     model = SOA
     keyvalue_attr = "keyvalue_set"
 

--- a/cyder/api/v1/endpoints/dns/srv/tests.py
+++ b/cyder/api/v1/endpoints/dns/srv/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.srv.models import SRV
+from cyder.api.v1.tests.base import APITests
 
 
-class SRVAPI_Test(DNSAPITests):
+class SRVAPI_Test(APITests):
+    __test__ = True
     model = SRV
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/sshfp/tests.py
+++ b/cyder/api/v1/endpoints/dns/sshfp/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.sshfp.models import SSHFP
+from cyder.api.v1.tests.base import APITests
 
 
-class SSHFPAPI_Test(DNSAPITests):
+class SSHFPAPI_Test(APITests):
+    __test__ = True
     model = SSHFP
 
     def create_data(self):

--- a/cyder/api/v1/endpoints/dns/tests.py
+++ b/cyder/api/v1/endpoints/dns/tests.py
@@ -1,5 +1,0 @@
-from cyder.api.v1.tests.base import APITests
-
-
-class DNSAPITests(APITests):
-    root = 'dns'

--- a/cyder/api/v1/endpoints/dns/txt/tests.py
+++ b/cyder/api/v1/endpoints/dns/txt/tests.py
@@ -1,8 +1,9 @@
-from cyder.api.v1.endpoints.dns.tests import DNSAPITests
 from cyder.cydns.txt.models import TXT
+from cyder.api.v1.tests.base import APITests
 
 
-class TXTAPI_Test(DNSAPITests):
+class TXTAPI_Test(APITests):
+    __test__ = True
     model = TXT
 
     def create_data(self):

--- a/cyder/api/v1/tests/base.py
+++ b/cyder/api/v1/tests/base.py
@@ -1,6 +1,7 @@
 import json
 from django.contrib.auth.models import User
 from django.test.client import Client
+from django.test import TestCase
 
 from cyder.api.authtoken.models import Token
 from cyder.cydns.domain.models import Domain
@@ -35,7 +36,7 @@ def build_domain(label, domain_obj):
 
 class APIKVTestMixin(object):
     """Mixin to test endpoints with key-value support."""
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         if not hasattr(self, "keyvalue_attr"):
             self.keyvalue_attr = self.model.__name__.lower() + "keyvalue_set"
 
@@ -55,7 +56,7 @@ class APIKVTestMixin(object):
         self.model.objects.filter(id=obj.id).delete()
 
 
-class APITests(object):
+class APITests(TestCase):
     """Base class for API Tests. This contains a lot of helpful methods,
     the core tests to run on every object, and the code that starts off
     building the test data.
@@ -91,6 +92,7 @@ class APITests(object):
     inherit from this class and create basic test data, while allowing the
     classes that inherit from it to define the case-specific data.
     """
+    __test__ = False
     fixtures = ['test_users/test_users.json']
 
     client = Client()
@@ -99,13 +101,12 @@ class APITests(object):
     f_object_list_url = "/api/v{0}/{1}/{2}/"
     f_object_url = "/api/v{0}/{1}/{2}/{3}/"
 
-    def __init__(self, *args, **kwargs):
-        if hasattr(self, 'urlname'):
-            urlname = getattr(self, 'urlname')
+    def setUp(self):
+        if hasattr(self, "url"):
+            url = self.url
         else:
-            urlname = str(self.model.__name__).lower()
-
-        root = getattr(self, 'root')
+            url = self.model.get_list_url()
+        root, urlname = tuple(url.strip("/").split("/"))
 
         self.domain, self.view = build_sample_domain()
         self.token = Token.objects.create(


### PR DESCRIPTION
This should fix the intermittent issue we were experiencing where data would not be purged from the test database in between different classes of tests (https://github.com/OSU-Net/cyder/issues/406). Seems to be working for me, anyway.
