### PR TITLE
Remove extra table cell from range detail view

### DIFF
--- a/cyder/templates/range/range_detail.html
+++ b/cyder/templates/range/range_detail.html
@@ -85,7 +85,7 @@
                 {% if request.user.get_profile().has_perm(request, 2, obj_class='staticinterface') and obj.range_type == 'st' %}
                   <a class="btn submit a" href={{ url('system-create', x[1].__str__()) }}>Static Interface</a>
                 {% endif %}
-                <td>
+              </td>
             </tr>
           {% else %}
             {% for record_ip, record_set in x %}


### PR DESCRIPTION
Somebody forgot the slash before the tag, starting a new `td` instead of ending the previous one.
