### PR TITLE
Ranges now update usage when an interface is moved between them

### DIFF
--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -142,7 +142,7 @@ class DynamicInterface(BaseModel, ObjectUrlMixin):
     def save(self, *args, **kwargs):
         update_range_usage = kwargs.pop('update_range_usage', True)
         old_range = None
-        if self.range and self.id is not None and update_range_usage:
+        if self.id is not None:
             old_range = DynamicInterface.objects.get(id=self.id).range
 
         super(DynamicInterface, self).save()

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -150,7 +150,7 @@ class StaticInterface(BaseAddressRecord, BasePTR):
         self.urd = kwargs.pop('update_reverse_domain', True)
         self.clean_reverse()  # BasePTR
         old_range = None
-        if self.range and self.id is not None and update_range_usage:
+        if self.id is not None:
             old_range = StaticInterface.objects.get(id=self.id).range
 
         super(StaticInterface, self).save(*args, **kwargs)

--- a/cyder/cydns/address_record/models.py
+++ b/cyder/cydns/address_record/models.py
@@ -164,7 +164,7 @@ class AddressRecord(BaseAddressRecord):
     def save(self, *args, **kwargs):
         update_range_usage = kwargs.pop('update_range_usage', True)
         old_range = None
-        if self.ip_str and self.id is not None and update_range_usage:
+        if self.id is not None:
             old_ip = AddressRecord.objects.get(id=self.id).ip_str
             old_range = find_range(old_ip)
         super(AddressRecord, self).save(*args, **kwargs)

--- a/cyder/cydns/ptr/models.py
+++ b/cyder/cydns/ptr/models.py
@@ -113,7 +113,7 @@ class PTR(BasePTR, Ip, LabelDomainMixin, CydnsRecord):
     def save(self, *args, **kwargs):
         update_range_usage = kwargs.pop('update_range_usage', True)
         old_range = None
-        if self.ip_str and self.id is not None and update_range_usage:
+        if self.id is not None:
             old_ip = PTR.objects.get(id=self.id).ip_str
             old_range = find_range(old_ip)
 


### PR DESCRIPTION
Previously, if you decided to update an interfaces range/ip the save method would update the range usage of the range it was moved to but no the range it was moved from. This pr fixes this issue.
