### PR TITLE
Preferred container

### DIFF
--- a/cyder/management/commands/dhcp_migrate.py
+++ b/cyder/management/commands/dhcp_migrate.py
@@ -412,8 +412,9 @@ def migrate_user():
     for username, preferred_zone_id in result:
         username = username.lower()
         user, _ = User.objects.get_or_create(username=username)
+        user = user.get_profile()
         default_ctnr = maintain_find_zone(preferred_zone_id)
-        if default_ctnr != user.default_ctnr:
+        if default_ctnr and default_ctnr != user.default_ctnr:
             user.default_ctnr = default_ctnr
             user.save()
 


### PR DESCRIPTION
This migrates the preferred container from Maintain. Just in the backend though, it's not set up to do anything in the frontend.

Related to https://github.com/OSU-Net/cyder/issues/296.
