### PR TITLE
Change search directive to match documentation

### DIFF
--- a/cyder/search/compiler/invparsley.py
+++ b/cyder/search/compiler/invparsley.py
@@ -21,7 +21,7 @@ AND = <letter+>:and_ ?(and_ == 'AND') -> self.AND_op()
 OR = <letter+>:or_ ?(or_ == 'OR') -> self.OR_op()
 
 # Directive
-EQ = '=:'
+EQ = ':'
 d_lhs = letter | '_'
 d_rhs = letterOrDigit | special | '/'
 DRCT = <d_lhs+>:d EQ <d_rhs+>:v -> self.directive(d, v)

--- a/cyder/search/tests/test_dns.py
+++ b/cyder/search/tests/test_dns.py
@@ -37,15 +37,15 @@ class SearchDNSTests(TestCase):
         self.assertEqual(len(res['NS']), 2)
         self.assertEqual(len(res['DOMAIN']), 2)
 
-        res, error = self.search("wee1.wee.mozilla.com type=:SOA")
+        res, error = self.search("wee1.wee.mozilla.com type:SOA")
         self.assertFalse(error)
         self.assertEqual(len(res['SOA']), 1)
         self.assertEqual(len(res['NS']), 0)
         self.assertEqual(len(res['DOMAIN']), 0)
 
         res, error = self.search(
-            "wee1.wee.mozilla.com type=:NS OR "
-            "wee.wee.mozilla.com type=:DOMAIN")
+            "wee1.wee.mozilla.com type:NS OR "
+            "wee.wee.mozilla.com type:DOMAIN")
         self.assertFalse(error)
         self.assertEqual(len(res['SOA']), 0)
         self.assertEqual(len(res['NS']), 1)
@@ -77,38 +77,38 @@ class SearchDNSTests(TestCase):
         self.assertEqual(len(res['A']), 1)
         self.assertEqual(len(res['PTR']), 1)
 
-        res, error = self.search("host1.wee2.wee.mozilla.com type=:A")
+        res, error = self.search("host1.wee2.wee.mozilla.com type:A")
         self.assertFalse(error)
         self.assertEqual(len(res['A']), 1)
         self.assertEqual(len(res['PTR']), 0)
 
-        res, error = self.search("host1.wee2.wee.mozilla.com type=:PTR")
+        res, error = self.search("host1.wee2.wee.mozilla.com type:PTR")
         self.assertFalse(error)
         self.assertEqual(len(res['A']), 0)
         self.assertEqual(len(res['PTR']), 1)
 
-        res, error = self.search("host1.wee2.wee.mozilla.com type=:A "
-                                 "type=:PTR")
+        res, error = self.search("host1.wee2.wee.mozilla.com type:A "
+                                 "type:PTR")
         self.assertFalse(error)
         self.assertEqual(len(res['A']), 0)
         self.assertEqual(len(res['PTR']), 0)
 
     def test_integration3_zone(self):
         root_domain = create_fake_zone("wee3.wee.mozilla.com", "")
-        res, error = self.search("zone=:wee3.wee.mozilla.com")
+        res, error = self.search("zone:wee3.wee.mozilla.com")
         self.assertFalse(error)
         self.assertEqual(len(res['SOA']), 1)
         self.assertEqual(len(res['NS']), 1)
         cn = CNAME(label="host1", domain=root_domain, target="whop.whop")
         cn.save()
-        res, error = self.search("zone=:wee3.wee.mozilla.com host1")
+        res, error = self.search("zone:wee3.wee.mozilla.com host1")
         self.assertFalse(error)
         self.assertEqual(len(res['SOA']), 0)
         self.assertEqual(len(res['NS']), 0)
         self.assertEqual(len(res['CNAME']), 1)
 
-        res, error = self.search("zone=:wee3.wee.mozilla.com "
-                                 "type=:CNAME")
+        res, error = self.search("zone:wee3.wee.mozilla.com "
+                                 "type:CNAME")
         self.assertFalse(error)
         self.assertEqual(len(res['SOA']), 0)
         self.assertEqual(len(res['NS']), 0)

--- a/cyder/search/tests/test_parser.py
+++ b/cyder/search/tests/test_parser.py
@@ -19,17 +19,17 @@ class DRCTTest(T):
     rule = 'DRCT'
 
     def test1(self):
-        self.assertEqual(('foo', 'bar'), self.parse('foo=:bar'))
+        self.assertEqual(('foo', 'bar'), self.parse('foo:bar'))
 
     def test2(self):
         lhs = 'foo'
         rhs = '-df:,832kjda_'
-        self.assertEqual((lhs, rhs), self.parse('{0}=:{1}'.format(lhs, rhs)))
+        self.assertEqual((lhs, rhs), self.parse('{0}:{1}'.format(lhs, rhs)))
 
     def test3(self):
         lhs = 'foo'
         rhs = '-=df:,832kjda_'
-        self.fail('{0}=:{1}'.format(lhs, rhs))
+        self.fail('{0}:{1}'.format(lhs, rhs))
 
     def test4(self):
         self.fail('foo')
@@ -48,10 +48,6 @@ class TextTest(T):
 
     def test2(self):
         t = '!foo'
-        self.fail(t)
-
-    def test3(self):
-        t = 'foo=:bar'
         self.fail(t)
 
     def test4(self):
@@ -187,7 +183,7 @@ class EXPRTests(T):
         self.assertEqual(out, self.parse(t))
 
     def test22(self):
-        t = "type=:a !(c OR !b)"
+        t = "type:a !(c OR !b)"
         out = "(('type', 'a') AND (NOT (c OR (NOT b))))"
         self.assertEqual(out, self.parse(t))
 
@@ -202,6 +198,6 @@ class EXPRTests(T):
         self.assertEqual(out, self.parse(t))
 
     def test26(self):
-        t = "type=:foo.bar !type=:baz"
+        t = "type:foo.bar !type:baz"
         out = "(('type', 'foo.bar') AND (NOT ('type', 'baz')))"
         self.assertEqual(out, self.parse(t))


### PR DESCRIPTION
The existing search requires use of 'type=:A' instead of just 'type:A'  - this fixes that.
