### PR TITLE
Fix issue where API error details weren't displayed

### DIFF
--- a/cyder/api/v1/filter.py
+++ b/cyder/api/v1/filter.py
@@ -9,11 +9,6 @@ UNHANDLED_PARAMS = 'page', 'count',
 class InvalidQuery(exceptions.APIException):
     status_code = 400
 
-    def __init__(self, detail):
-        self.detail = detail
-        super(InvalidQuery, self).__init__(self)
-
-
 
 def namehack(field):
     """


### PR DESCRIPTION
Due to a small error on my part, exceptions raised in the API filter class had their associated messages erased. It turns out that the code which caused the issue was also completely redundant, so I removed it altogether.
