### PR TITLE
Optimize object_list existence check

### DIFF
--- a/cyder/base/views.py
+++ b/cyder/base/views.py
@@ -176,7 +176,7 @@ def cy_view(request, get_klasses_fn, template, pk=None, obj_type=None):
         form = FormKlass(instance=obj)
         object_list = _filter(request, Klass)
 
-        if obj_type == 'system' and not object_list:
+        if obj_type == 'system' and not object_list.exists():
             return redirect(reverse('system-create'))
 
         page_obj = make_paginator(request, do_sort(request, object_list), 50)


### PR DESCRIPTION
Before, in the System list view, the entire list of Systems was queried to check existence. This was a very slow query, so I removed it.
