### PR TITLE
Fix filter_by_ctnr

### DIFF
--- a/cyder/base/utils.py
+++ b/cyder/base/utils.py
@@ -136,7 +136,10 @@ def filter_by_ctnr(ctnr, Klass=None, objects=None):
         Klass = objects.model
 
     if ctnr.name in ['global', 'default']:
-        return objects or Klass.objects
+        if objects is None:
+            return Klass.objects
+        else:
+            return objects
 
     return Klass.filter_by_ctnr(ctnr, objects)
 


### PR DESCRIPTION
If an empty queryset (e.g., one generated via `Model.objects.none()`) is passed to `filter_by_ctnr`, it should return that empty queryset, not a queryset containing every object in the table.
