### PR TITLE
DynamicInterface MAC uniqueness validation fix

### DIFF
--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -113,8 +113,8 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
         super(DynamicInterface, self).clean(*args, **kwargs)
 
         siblings = self.range.dynamicinterface_set.filter(mac=self.mac)
-        if self.id:
-            siblings = siblings.exclude(id=self.id)
+        if self.pk is not None:
+            siblings = siblings.exclude(pk=self.pk)
         if siblings.exists():
             raise ValidationError(
                 "MAC address must be unique in this interface's range")


### PR DESCRIPTION
It seems I forgot that `qs.exclude(...)` doesn't modify `qs`.
