### PR TITLE
Fix user promotion bug

### DIFF
--- a/cyder/core/cyuser/views.py
+++ b/cyder/core/cyuser/views.py
@@ -245,10 +245,10 @@ def edit_user(request, username, action):
 
             else:
                 return HttpResponse(json.dumps(
-                    {'errors': {'__all__': 'Cannot complete action'}}))
+                    {'errors': {'__all__': 'Unknown action'}}))
         except:
             return HttpResponse(json.dumps(
-                {'errors': {'__all__': 'That user does not exist'}}))
+                {'errors': {'__all__': 'An error occurred'}}))
 
     return HttpResponse(json.dumps({'success': True}))
 


### PR DESCRIPTION
This pull request fixes an improperly handled exception that occurs when a user or admin on the 'global' container is promoted to superuser and causes an incorrect error message to be shown.
