### PR TITLE
Add management command to dump all MAC's

### DIFF
--- a/cyder/management/commands/mac_dump.py
+++ b/cyder/management/commands/mac_dump.py
@@ -62,17 +62,11 @@ class Command(BaseCommand):
                 except ObjectDoesNotExist:
                     zone_identifier = "No_other_id"
 
-            if interface.modified:
-                # Format to match: Tue Jun  3 10:33:57 2014
-                modified = interface.modified.strftime("%a %b %d %X %Y")
-            else:
-                modified = "More_than_90_days"
-
             interface_data = {
                 'mac': interface.mac.replace(':', ''),
                 'zone_identifier': zone_identifier,
                 'hostname': system.name,
-                'modified': modified,
+                'modified': interface.modified.strftime("%a %b %d %X %Y"),
             }
             interfaces.append(interface_data)
 


### PR DESCRIPTION
Resolves #714. This has never taken more than 4 minutes to run, so it should be safe to use in practice.

Current output

```
$ head maint_mac_db 
000000000001 zone.scf jcasctest More_than_90_days
000000000002 zone.ext-morrow ODFW-PIX More_than_90_days
```

Output of the management command:

```
$ head cyder_mac_db 
000000000001 zone.mu Mike-AndersonCo More_than_90_days
000000000002 zone.engr lennon More_than_90_days
```

You can test the command by running `./manage.py mac_dump -f cyder_mac_db`. If you don't pass the `-f` flag, the results will just be printed on stdout.

I still need to test if this script's output is compatible with the output of `radius-report`.
