### PR TITLE
Allow zones with no config

### DIFF
--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -389,12 +389,17 @@ class DNSBuilder(MutexMixin):
                                    root_domain=root_domain)
 
                 for view, file_meta, view_data in views_to_build:
-                    view_zone_stmts = zone_stmts.setdefault(view.name, [])
-                    # If we see a view in this loop it's going to end up in
-                    # the config
-                    view_zone_stmts.append(
-                        self.render_zone_stmt(soa, root_domain, file_meta)
-                    )
+                    if (root_domain.name, view.name) in ZONES_WITH_NO_CONFIG:
+                        self.log_notice(
+                            '!!! Not going to emit zone statements for {0}\n'
+                            .format(root_domain.name), root_domain=root_domain)
+                    else:
+                        view_zone_stmts = zone_stmts.setdefault(view.name, [])
+                        # If we see a view in this loop it's going to end up in
+                        # the config
+                        view_zone_stmts.append(
+                            self.render_zone_stmt(soa, root_domain, file_meta)
+                        )
 
                     # If it's dirty or we are rebuilding another view, rebuild
                     # the zone

--- a/cyder/settings/base.py
+++ b/cyder/settings/base.py
@@ -468,6 +468,19 @@ ZONES_FILE = "/tmp/dns_prod/cyzones/config/master.public"
 ZONE_PATH = "cyder/management/commands/lib/zones"
 ZONE_BLACKLIST = []
 
+# This list contains tuples that have a zone's name as their 0th element and a
+# view's name as the 1st element. For example:
+#
+# ('mozilla.net', 'public'),
+# ('mozilla.net', 'private')
+#
+# This will cause the public and private view of the mozilla.net zone to not
+# have a config statement in the produced config/master.private and
+# config/master.public files. The files net/mozilla/mozilla.net.public and
+# net/mozilla.net.private *will* be generated and written to disk.
+ZONES_WITH_NO_CONFIG = [
+]
+
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         # 'cyder.api.v1.permissions.ReadOnlyIfAuthenticated',


### PR DESCRIPTION
Resolves https://github.com/OSU-Net/cyder/issues/61. If a zone-view pair is added to the `ZONES_WITH_NO_CONFIG` setting, then it will not appear in the master config for that view on the next build. The configs will not be rebuilt unless there is a change to dns objects in cyder, but a rebuild can be forced with the `-f` flag.
