### PR TITLE
Nameservers correctly set container

### DIFF
--- a/cyder/cydns/nameserver/models.py
+++ b/cyder/cydns/nameserver/models.py
@@ -133,9 +133,8 @@ class Nameserver(CydnsRecord):
     glue = property(get_glue, set_glue, del_glue, "The Glue property.")
 
     def __init__(self, *args, **kwargs):
-        if 'ctnr' not in kwargs:
-            kwargs['ctnr'] = Ctnr.objects.get(pk=1)
         super(Nameserver, self).__init__(*args, **kwargs)
+        self.ctnr = Ctnr.objects.get(name="global")
 
     def delete(self, *args, **kwargs):
         self.check_no_ns_soa_condition(self.domain)


### PR DESCRIPTION
Nameservers don't really need the container field, so it's simply set as "global" and ignored. The previous implementation of this raised some issues when installing fixtures.
