### PR TITLE
Do not check container's domain against record's domain

### DIFF
--- a/cyder/core/cyuser/backends.py
+++ b/cyder/core/cyuser/backends.py
@@ -3,8 +3,8 @@ from cyder.base.constants import (LEVEL_GUEST, LEVEL_USER, LEVEL_ADMIN,
 
 
 def has_perm(self, request, action, obj=None, obj_class=None, ctnr=None):
-        return _has_perm(request.user, ctnr or request.session['ctnr'], action,
-            obj, obj_class)
+    return _has_perm(request.user, ctnr or request.session['ctnr'], action,
+        obj, obj_class)
 
 
 def _has_perm(user, ctnr, action, obj=None, obj_class=None):

--- a/cyder/core/cyuser/tests/test_perms.py
+++ b/cyder/core/cyuser/tests/test_perms.py
@@ -222,7 +222,7 @@ class PermissionsTest(TestCase):
         self.check_perms_each_user(Nameserver(domain=domain), ns_perm_table)
 
         for obj in domain_records:
-            self.check_perms_each_user(obj, perm_table)
+            self.check_perms_each_user(obj, perm_table, set_same_ctnr=True)
 
     def setup_request(self):
         """
@@ -241,31 +241,41 @@ class PermissionsTest(TestCase):
         self.ctnr_user.save()
         self.ctnr_guest.save()
 
-    def check_perms_each_user(self, obj, perm_table):
+    def check_perms_each_user(self, obj, perm_table, set_same_ctnr=False):
         """
         Utility function for checking permissions
         """
         # Superuser.
         self.request.user = self.superuser
         self.request.session['ctnr'] = self.ctnr_guest
+        if set_same_ctnr:
+            obj.ctnr = self.ctnr_guest
         self.assert_perms(obj, perm_table, 'superuser')
 
         # Cyder admin.
         self.request.user = self.cyder_admin
         self.request.session['ctnr'] = self.ctnr_admin
+        if set_same_ctnr:
+            obj.ctnr = self.ctnr_admin
         self.assert_perms(obj, perm_table, 'cyder_admin')
 
         # Admin.
         self.request.user = self.test_user
         self.request.session['ctnr'] = self.ctnr_admin
+        if set_same_ctnr:
+            obj.ctnr = self.ctnr_admin
         self.assert_perms(obj, perm_table, 'admin')
 
         # User.
         self.request.session['ctnr'] = self.ctnr_user
+        if set_same_ctnr:
+            obj.ctnr = self.ctnr_user
         self.assert_perms(obj, perm_table, 'user')
 
         # Guest.
         self.request.session['ctnr'] = self.ctnr_guest
+        if set_same_ctnr:
+            obj.ctnr = self.ctnr_guest
         self.assert_perms(obj, perm_table, 'guest')
 
         # Pleb.


### PR DESCRIPTION
Now that these records have their own container fields, this check is no longer necessary. (The validation that a record's container matches its domain's container is being done elsewhere)
