### PR TITLE
Fix error message object list

### DIFF
--- a/cyder/cydns/cname/models.py
+++ b/cyder/cydns/cname/models.py
@@ -143,7 +143,8 @@ class CNAME(LabelDomainMixin, CydnsRecord):
         if qset:
             objects = qset.all()
             raise ValidationError(
-                "Objects with this name already exist: {0}".format(objects)
+                "Objects with this name already exist: {0}".format(
+                    ', '.join(unicode(object) for object in objects))
             )
 
         MX = get_model('cyder', 'MX')

--- a/cyder/cydns/domain/models.py
+++ b/cyder/cydns/domain/models.py
@@ -212,7 +212,9 @@ class Domain(BaseModel, ObjectUrlMixin):
             if qset:
                 objects = qset.all()
                 raise ValidationError("Objects with this name already "
-                                      "exist {0}".format(objects))
+                                      "exist: {0}".format(
+                    ', '.join(unicode(object) for object in objects))
+                )
         else:
             db_self = Domain.objects.get(pk=self.pk)
             if db_self.name != self.name and self.domain_set.exists():


### PR DESCRIPTION
If you try to create a CNAME whose `fqdn` collides with an existing object, the object list in the validation error doesn't display correctly in the form because the list items aren't formatted correctly. The same is true of a Domain whose `name` collides with an existing object.
