### PR TITLE
In detail views, show main object info in a vertical list instead of a one-row table

### DIFF
--- a/cyder/base/tablefier.py
+++ b/cyder/base/tablefier.py
@@ -193,6 +193,14 @@ class Tablefier:
 
         return objs, data, urls
 
+    @staticmethod 
+    def remove_field(table_dict, header_name): 
+        for i, header in enumerate(table_dict['headers']):
+          if header[0] == header_name:
+            del table_dict['headers'][i]
+            del table_dict['data'][0][i]
+            return 
+
     def get_table(self):
         if not self.objects:
             return None

--- a/cyder/base/views.py
+++ b/cyder/base/views.py
@@ -319,10 +319,20 @@ def cy_detail(request, Klass, template, obj_sets, pk=None, obj=None, **kwargs):
             'page_obj': page_obj,
             'table': table
         })
+
     if obj_type == 'user':
         table = tablefy((obj,), info=False, request=request, update=False)
     else:
         table = tablefy((obj,), info=False, request=request)
+    
+    #remove references to Info from the object table
+    for i, header in enumerate(table['headers']):
+      if header[0] == 'Info':
+        del table['headers'][i]
+
+    for i, obj in enumerate(table['data'][0]):
+      if 'class' in obj and obj['class'][0] == 'info':
+        del table['data'][0][i]
 
     return render(request, template, dict({
         'obj': obj,

--- a/cyder/base/views.py
+++ b/cyder/base/views.py
@@ -324,15 +324,10 @@ def cy_detail(request, Klass, template, obj_sets, pk=None, obj=None, **kwargs):
         table = tablefy((obj,), info=False, request=request, update=False)
     else:
         table = tablefy((obj,), info=False, request=request)
-    
-    #remove references to Info from the object table
-    for i, header in enumerate(table['headers']):
-      if header[0] == 'Info':
-        del table['headers'][i]
 
-    for i, obj in enumerate(table['data'][0]):
-      if 'class' in obj and obj['class'][0] == 'info':
-        del table['data'][0][i]
+    from cyder.base.tablefier import Tablefier  
+    Tablefier.remove_field(table, 'Info')
+    Tablefier.remove_field(table, 'Actions')
 
     return render(request, template, dict({
         'obj': obj,

--- a/cyder/core/system/views.py
+++ b/cyder/core/system/views.py
@@ -16,7 +16,7 @@ from cyder.cydhcp.interface.dynamic_intr.models import DynamicInterface
 from cyder.cydhcp.interface.dynamic_intr.forms import DynamicInterfaceForm
 from cyder.cydhcp.interface.static_intr.models import StaticInterface
 from cyder.cydhcp.interface.static_intr.forms import StaticInterfaceForm
-
+from cyder.base.tablefier import Tablefier
 
 def system_detail(request, pk):
     try:
@@ -45,8 +45,8 @@ def system_detail(request, pk):
                                      request=request)))
 
     related_systems.discard(system)
+
     return render(request, 'system/system_detail.html', {
-        'system_table': tablefy([system], info=False, request=request),
         'attrs_table': tablefy(attrs, request=request),
         'static_intr_tables': static_intr,
         'dynamic_intr_tables': dynamic_intr,

--- a/cyder/cydhcp/build/builder.py
+++ b/cyder/cydhcp/build/builder.py
@@ -89,7 +89,7 @@ class DHCPBuilder(MutexMixin):
 
             raise Exception(msg)
         except IOError as e:
-            if e.errno == 2:  # IOError: [Errno 2] No such file or directory
+            if e.errno == errno.ENOENT:  # IOError: [Errno 2] No such file or directory
                 pass
             else:
                 raise

--- a/cyder/cydhcp/network/views.py
+++ b/cyder/cydhcp/network/views.py
@@ -8,6 +8,7 @@ from cyder.cydhcp.network.utils import calc_networks
 def network_detail(request, pk):
     network = get_object_or_404(Network, pk=pk)
     parent_networks, child_networks = calc_networks(network)
+
     return cy_detail(request, Network, 'network/network_detail.html', {
         'Ranges': 'range_set',
         'Parent Networks': parent_networks,

--- a/cyder/cydhcp/range/views.py
+++ b/cyder/cydhcp/range/views.py
@@ -64,14 +64,25 @@ def range_detail(request, pk):
         dynamic_interfaces = DynamicInterface.objects.filter(range=mrange)
         dynamic_interfaces_page_obj = make_paginator(
             request, do_sort(request, dynamic_interfaces), 10)
+    
+    range_table = tablefy((mrange,), info=False, request=request)
 
+    for i, header in enumerate(range_table['headers']):
+      if header[0] == 'Info':
+        del range_table['headers'][i]
+
+    #remove references to Info from the object table
+    for i, obj in enumerate(range_table['data'][0]):
+      if 'class' in obj and obj['class'][0] == 'info':
+        del range_table['data'][0][i]
+    
     if ip_usage_percent:
         ip_usage_percent = "{0}%".format(ip_usage_percent)
     return render(request, 'range/range_detail.html', {
         'obj': mrange,
         'obj_type': 'range',
         'pretty_obj_type': mrange.pretty_type,
-        'ranges_table': tablefy((mrange,), info=False, request=request),
+        'ranges_table': range_table, 
         'range_data': make_paginator(request, range_data, 50),
         'range_type': range_type,
         'attrs_table': tablefy(mrange.rangeav_set.all(),

--- a/cyder/cydhcp/range/views.py
+++ b/cyder/cydhcp/range/views.py
@@ -67,15 +67,10 @@ def range_detail(request, pk):
     
     range_table = tablefy((mrange,), info=False, request=request)
 
-    for i, header in enumerate(range_table['headers']):
-      if header[0] == 'Info':
-        del range_table['headers'][i]
+    from cyder.base.tablefier import Tablefier
+    Tablefier.remove_field(range_table, 'Info')
+    Tablefier.remove_field(range_table, 'Actions')
 
-    #remove references to Info from the object table
-    for i, obj in enumerate(range_table['data'][0]):
-      if 'class' in obj and obj['class'][0] == 'info':
-        del range_table['data'][0][i]
-    
     if ip_usage_percent:
         ip_usage_percent = "{0}%".format(ip_usage_percent)
     return render(request, 'range/range_detail.html', {

--- a/cyder/cydhcp/vrf/views.py
+++ b/cyder/cydhcp/vrf/views.py
@@ -2,6 +2,8 @@ from django.db.models import Q
 from django.shortcuts import get_object_or_404
 
 from cyder.cydhcp.interface.static_intr.models import StaticInterface
+from cyder.cydhcp.network.models import Network
+from cyder.cydhcp.site.models import Site
 from cyder.base.views import cy_detail
 from cyder.cydhcp.vrf.models import Vrf
 
@@ -28,10 +30,13 @@ def vrf_detail(request, pk):
     static_intr_q = get_static_intr_q(vrf)
     static_intrs = (
         StaticInterface.objects.filter(static_intr_q) if static_intr_q else ())
-
+    networks = Network.objects.filter(vrf=vrf)
+    
     return cy_detail(request, Vrf, 'vrf/vrf_detail.html', {
         'Dynamic Interfaces': DynamicInterface.objects.filter(
             range__network__vrf=vrf),
         'Static Interfaces': static_intrs,
+        #'Sites': ,
+        'Networks': networks,
         'Attributes': 'vrfav_set',
     }, pk=pk, obj=vrf)

--- a/cyder/cydhcp/vrf/views.py
+++ b/cyder/cydhcp/vrf/views.py
@@ -31,12 +31,13 @@ def vrf_detail(request, pk):
     static_intrs = (
         StaticInterface.objects.filter(static_intr_q) if static_intr_q else ())
     networks = Network.objects.filter(vrf=vrf)
-    
+    sites = Site.objects.filter(network__in=networks).distinct()
+
     return cy_detail(request, Vrf, 'vrf/vrf_detail.html', {
         'Dynamic Interfaces': DynamicInterface.objects.filter(
             range__network__vrf=vrf),
         'Static Interfaces': static_intrs,
-        #'Sites': ,
+        'Sites': sites,
         'Networks': networks,
         'Attributes': 'vrfav_set',
     }, pk=pk, obj=vrf)

--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -5,6 +5,8 @@ import os
 import sys
 import syslog
 import time
+import errno
+
 from traceback import format_exception
 
 from cyder.settings import BINDBUILD, ZONES_WITH_NO_CONFIG
@@ -467,7 +469,7 @@ class DNSBuilder(MutexMixin):
 
             raise Exception(msg)
         except IOError as e:
-            if e.errno == 2:  # IOError: [Errno 2] No such file or directory
+            if e.errno == errno.ENOENT:  # IOError: [Errno 2] No such file or directory
                 pass
             else:
                 raise

--- a/cyder/cydns/cybind/serial_utils.py
+++ b/cyder/cydns/cybind/serial_utils.py
@@ -1,6 +1,6 @@
 import re
 import os
-
+import errno
 
 def get_serial(file_):
     """
@@ -13,7 +13,7 @@ def get_serial(file_):
         with open(file_, 'r') as fd:
             return _str_get_serial(fd)
     except IOError as e:
-        if e.errno == 2:  # IOError: [Errno 2] No such file or directory
+        if e.errno == errno.ENOENT:  # IOError: [Errno 2] No such file or directory
             return ''
         else:
             raise

--- a/cyder/templates/base/detail.html
+++ b/cyder/templates/base/detail.html
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block content %}
- {{ render_object(request, obj_table) }}
+  {{ render_object(request, obj_table) }}
   {% for table in tables %}
     {% if table.table or "Attributes" in table.name %}
       {% if "Attributes" in table.name %}

--- a/cyder/templates/base/detail.html
+++ b/cyder/templates/base/detail.html
@@ -1,5 +1,5 @@
 {% extends "base/base.html" %}
-{% from "base/tables.html" import render_table %}
+{% from "base/tables.html" import render_table, render_object %}
 
 {% set obj_type_perm = request.user.get_profile().has_perm(request, 2, obj=obj) %}
 
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block content %}
-  {{ render_table(request, obj_table) }}
+ {{ render_object(request, obj_table) }}
   {% for table in tables %}
     {% if table.table or "Attributes" in table.name %}
       {% if "Attributes" in table.name %}
@@ -63,5 +63,5 @@
         {{ render_table(request, table.table) }}
       {% endif %}
     {% endif %}
-  {% endfor %}
+  {% endfor %} 
 {% endblock %}

--- a/cyder/templates/base/tables.html
+++ b/cyder/templates/base/tables.html
@@ -62,7 +62,7 @@
             <td>
             {% for cell in col['value'] %}
               {% if col['url'][loop.index0] %}
-                <a class="info" 
+                <a
                 {% if col['data'] %}
                   {% if col['data'][loop.index0] %}
                     {% for data in col['data'][loop.index0] %}

--- a/cyder/templates/base/tables.html
+++ b/cyder/templates/base/tables.html
@@ -51,73 +51,40 @@
 {% if object_table %}
   <table id="obj-info">
 
-    {% set i = 0 %}
     {% for row in object_table['data']%}
       {% for col in row %}
-        {% set header, sort_field = object_table['headers'][i] %}
-        
-        {% if header == "Info" %} {# don't render row for 'Info' because it's useless (links back to same page) #}
-          {% set i = i + 1 %}
-          {% continue %}
-        {% endif %}
-        
-        {% if header == "Actions" %} {# render all action buttons in the same table cell #}
-          <td class = "{{ header | lower }}_column"><b>{{ header }}</b></td>
-          <td>
-          {% for cell in col['value'] %}
-            {% if col['url'][loop.index0] %}
-              <a class="info" 
-              {% if col['data'] %}
-                {% if col['data'][loop.index0] %}
-                  {% for data in col['data'][loop.index0] %}
-                    data-{{ data[0] }}="{{ data[1] }}"
-                  {% endfor %}
-                {% endif %}
-              {% endif %}
-                href="{{ col['url'][loop.index0] }}">
-              {% if col['img'] and col['img'][loop.index0] %}
-                <img alt="{{ cell }}" src="{{ col['img'][loop.index0] }}"/>
-              {% else %}
-                {{ cell }} 
-              {% endif %}
-              </a>
-            {% endif %}
-          {% endfor %}
-          </td>
-
-          {% set i = i + 1 %}
-          {% continue %}
-        {% endif %}
+        {% set header, sort_field = object_table['headers'][loop.index0] %}
+         
         <tr>
-          {#{% if sort_field %}
-            <td class="{{ header | lower }}_column">{{ sort_link(request, header, sort_field)|safe }}</td>
-          {% else %}#}
-            <td class="{{ header | lower }}_column"><b>{{ header }}</b></td>
-          {#{% endif %}#}
-
-          {% for cell in col['value'] %}
-            {% if col['url'][loop.index0] %}
-              <td><a class="info" 
-              {% if col['data'] %}
-                {% if col['data'][loop.index0] %}
-                  {% for data in col['data'][loop.index0] %}
-                    data-{{ data[0] }}="{{ data[1] }}"
-                  {% endfor %}
+          <td class="{{ header | lower }}_column"><b>{{ header }}</b></td>
+          
+          {% if col['value'] %}
+            <td>
+            {% for cell in col['value'] %}
+              {% if col['url'][loop.index0] %}
+                <a class="info" 
+                {% if col['data'] %}
+                  {% if col['data'][loop.index0] %}
+                    {% for data in col['data'][loop.index0] %}
+                      data-{{ data[0] }}="{{ data[1] }}"
+                    {% endfor %}
+                  {% endif %}
                 {% endif %}
-              {% endif %}
-                href="{{ col['url'][loop.index0] }}">
-              {% if col['img'] and col['img'][loop.index0] %}
-                <img alt="{{ cell }}" src="{{ col['img'][loop.index0] }}"/>
+                  href="{{ col['url'][loop.index0] }}">
+                {% if col['img'] and col['img'][loop.index0] %}
+                  <img alt="{{ cell }}" src="{{ col['img'][loop.index0] }}"/>
+                {% else %}
+                  {{ cell }} 
+                {% endif %}
+                </a>
               {% else %}
-                {{ cell }} 
+                {{cell}}
               {% endif %}
-              </a></td>
-            {% else %}
-              <td>{{cell}}</td>
-            {% endif %}
-          {% endfor %}
+            {% endfor %}
+            </td>
+          {% endif %}
+        
         </tr>
-        {% set i = i + 1 %}
       {% endfor %}
     {% endfor %}
   </table>

--- a/cyder/templates/base/tables.html
+++ b/cyder/templates/base/tables.html
@@ -45,3 +45,81 @@
 
 {% endif %}
 {% endmacro %}
+
+{# render a table containing a single object so that it doesn't look like a table #}
+{% macro render_object(request, object_table, class) %}
+{% if object_table %}
+  <table id="obj-info">
+
+    {% set i = 0 %}
+    {% for row in object_table['data']%}
+      {% for col in row %}
+        {% set header, sort_field = object_table['headers'][i] %}
+        
+        {% if header == "Info" %} {# don't render row for 'Info' because it's useless (links back to same page) #}
+          {% set i = i + 1 %}
+          {% continue %}
+        {% endif %}
+        
+        {% if header == "Actions" %} {# render all action buttons in the same table cell #}
+          <td class = "{{ header | lower }}_column"><b>{{ header }}</b></td>
+          <td>
+          {% for cell in col['value'] %}
+            {% if col['url'][loop.index0] %}
+              <a class="info" 
+              {% if col['data'] %}
+                {% if col['data'][loop.index0] %}
+                  {% for data in col['data'][loop.index0] %}
+                    data-{{ data[0] }}="{{ data[1] }}"
+                  {% endfor %}
+                {% endif %}
+              {% endif %}
+                href="{{ col['url'][loop.index0] }}">
+              {% if col['img'] and col['img'][loop.index0] %}
+                <img alt="{{ cell }}" src="{{ col['img'][loop.index0] }}"/>
+              {% else %}
+                {{ cell }} 
+              {% endif %}
+              </a>
+            {% endif %}
+          {% endfor %}
+          </td>
+
+          {% set i = i + 1 %}
+          {% continue %}
+        {% endif %}
+        <tr>
+          {#{% if sort_field %}
+            <td class="{{ header | lower }}_column">{{ sort_link(request, header, sort_field)|safe }}</td>
+          {% else %}#}
+            <td class="{{ header | lower }}_column"><b>{{ header }}</b></td>
+          {#{% endif %}#}
+
+          {% for cell in col['value'] %}
+            {% if col['url'][loop.index0] %}
+              <td><a class="info" 
+              {% if col['data'] %}
+                {% if col['data'][loop.index0] %}
+                  {% for data in col['data'][loop.index0] %}
+                    data-{{ data[0] }}="{{ data[1] }}"
+                  {% endfor %}
+                {% endif %}
+              {% endif %}
+                href="{{ col['url'][loop.index0] }}">
+              {% if col['img'] and col['img'][loop.index0] %}
+                <img alt="{{ cell }}" src="{{ col['img'][loop.index0] }}"/>
+              {% else %}
+                {{ cell }} 
+              {% endif %}
+              </a></td>
+            {% else %}
+              <td>{{cell}}</td>
+            {% endif %}
+          {% endfor %}
+        </tr>
+        {% set i = i + 1 %}
+      {% endfor %}
+    {% endfor %}
+  </table>
+{% endif %}
+{% endmacro %}

--- a/cyder/templates/range/range_detail.html
+++ b/cyder/templates/range/range_detail.html
@@ -19,7 +19,6 @@
     <a href="{{ url('build-network', obj.network.pk) }}">DHCP Build Output</a>
   {% endif %}
 
-  {# {{ render_table(request, ranges_table) }} #}
   {{ render_object(request, ranges_table) }}
   {% if allow_list %}
     <h3>Allowed</h3>

--- a/cyder/templates/range/range_detail.html
+++ b/cyder/templates/range/range_detail.html
@@ -1,5 +1,5 @@
 {% extends "cydhcp/cydhcp_detail.html" %}
-{% from "base/tables.html" import render_table %}
+{% from "base/tables.html" import render_table, render_object %}
 {% from "base/utility.html" import create_button %}
 
 {% block extra_action_bar %}
@@ -19,8 +19,8 @@
     <a href="{{ url('build-network', obj.network.pk) }}">DHCP Build Output</a>
   {% endif %}
 
-  {{ render_table(request, ranges_table) }}
-
+  {# {{ render_table(request, ranges_table) }} #}
+  {{ render_object(request, ranges_table) }}
   {% if allow_list %}
     <h3>Allowed</h3>
     <table class="table">

--- a/cyder/templates/range/range_detail.html
+++ b/cyder/templates/range/range_detail.html
@@ -21,7 +21,6 @@
 
   {{ render_object(request, ranges_table) }}
   {% if allow_list %}
-    <h3>Allowed</h3>
     <table class="table">
         <thead><th>Allowed</th></thead>
         <tbody>

--- a/cyder/templates/search/search_help.html
+++ b/cyder/templates/search/search_help.html
@@ -13,7 +13,7 @@
       <table border="0" cellspacing="10">
       <h2><u>Search Patterns</u></h2>
       <tr>
-        <td>
+        <td id="sub-header">
           a&#8209;zA&#8209;Z0&#8209;9.
         </td>
         <td>
@@ -21,13 +21,13 @@
           Bare words are used to match text in objects. Objects that match <b>all</b> bare words
           are returned. For example: <code>foo bar scl3</code> will match objects that contain the
           words <code>foo</code> <b>AND</b> <code>bar</code> <b>AND</b> <code>scl3</code>
-          ('<code>foo.bar.scl3.mozilla.com</code>' would match but
-          <code>foo.baz.scl3.mozilla.com</code> would not).
+          ('<code>foo.bar.scl3.com</code>' would match but
+          <code>foo.baz.scl3.com</code> would not).
           </p>
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           '/'
         </td>
         <td>
@@ -38,13 +38,13 @@
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           '..'
         </td>
         <td>
           <p>
           When you surround '..' with numbers, inventory will expand your query into multiple
-          queires. For example: A search for <code>web1..3</code> is understood to be a search for
+          queries. For example: A search for <code>web1..3</code> is understood to be a search for
           <code>web1</code> <b>OR</b> <code>web2</code> <b>OR</b> <code>web3</code>.
           </p>
         </td>
@@ -53,12 +53,12 @@
     <table border="0" cellspacing="10">
       <h2><u>Operators</u></h2>
       <tr>
-        <td>
-          '-'
+        <td id="sub-header">
+          '!'
         </td>
         <td>
           <p>
-          The dash character '-' can be used to negate any search pattern. It can also negate the
+          An exclamation point can be used to negate any search pattern. It can also negate the
           <code>type</code> directive.
           </p>
         </td>
@@ -67,20 +67,20 @@
     <table border="0" cellspacing="10">
       <h2><u>Directives</u></h2>
       <tr>
-        <td>
+        <td id="sub-header">
           type:
         </td>
         <td>
           <p>
           The 'type' directive can be used to target a type of DNS record. For example: to see all
           CNAME records that contained the word 'web' you could search <code>type:CNAME web</code>.
-          To search for StaticInterface records or domains use <code>type:STATIC</code> and
+          To search for Static Interface records or domains use <code>type:STATIC</code> and
           <code>type:Domain</code>. Type is case insensitive.
           </p>
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           site:
         </td>
         <td>
@@ -93,7 +93,7 @@
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           vlan:
         </td>
         <td>
@@ -106,7 +106,7 @@
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           network:
         </td>
         <td>
@@ -118,7 +118,7 @@
         </td>
       </tr>
       <tr>
-        <td>
+        <td id="sub-header">
           range:
         </td>
         <td>

--- a/cyder/templates/system/system_detail.html
+++ b/cyder/templates/system/system_detail.html
@@ -33,8 +33,6 @@
 {% endblock %}
 
 {% block content %}
-  {{ render_table(request, system_table, 'system') }}
-
   {% if attrs_table %}
     <h3 id="attr_title">System Attributes</h3>
     {{ render_table(request, attrs_table, 'attrs_table') }}

--- a/media/css/base.scss
+++ b/media/css/base.scss
@@ -7,6 +7,17 @@
     width: 1280px;
 }
 
+#search input
+{
+    font-family: "Courier New", Courier, monospace;
+}
+
+#sub-header
+{
+    max-width: 60px;
+    min-width: 60px;
+}
+
 html {
     border: 0;
     margin: 0;

--- a/media/css/tables.scss
+++ b/media/css/tables.scss
@@ -3,6 +3,10 @@
 .info_column, .actions_column, .remove_column {
     width: 50px;
 }
+table#obj-info {
+    padding-top: 12px;
+    padding-bottom: 5px;
+}
 table.table {
     clear: both;
     margin-bottom: 13px;

--- a/media/js/admin.js
+++ b/media/js/admin.js
@@ -2,6 +2,7 @@ $(document).ready( function() {
     var data = $('#view-metadata');
     var searchUserUrl = data.attr( 'data-searchUserUrl' )
     $('#user-searchbox').autocomplete( {
+         global: false,
          minLength: 1,
          source: searchUserUrl,
          delay: 400,

--- a/media/js/views.js
+++ b/media/js/views.js
@@ -58,6 +58,7 @@ $(document).ready( function() {
             minLength: 1,
             source: function( request, response ) {
                 $.ajax({
+                    global: false,
                     url: '/eav/search',
                     dataType: 'json',
                     data: {


### PR DESCRIPTION
**Resolves issues #446, #704, #332, #828, #831 and #768*.**

*Changed how main object is rendered in detail view to make it not look like a table.  'Info' row is also removed as it doesn't do anything useful. 

\* Examples of using '!' to negate a query still need to be added.