### PR TITLE
Simplify (?) config builder logging

### DIFF
--- a/cyder/base/mixins.py
+++ b/cyder/base/mixins.py
@@ -197,10 +197,10 @@ class MutexMixin(object):
         except IOError as exc_value:
             # IOError: [Errno 2] No such file or directory
             if exc_value[0] == 2:
-                raise Exception("Failed to acquire lock on {0}, but the "
-                                "the process that has it hasn't written "
-                                "the PID file {1} yet."
-                                .format(self.lock_file, self.pid_file))
+                self.error(
+                    "Failed to acquire lock on {0}, but the the process that "
+                    "has it hasn't written the PID file {1} yet.".format(
+                        self.lock_file, self.pid_file))
             else:
                 raise
 
@@ -219,5 +219,5 @@ class MutexMixin(object):
         return True
 
     def _lock_failure(self, pid):
-        raise Exception('Failed to acquire lock on {0}. Process {1} currently '
+        self.error('Failed to acquire lock on {0}. Process {1} currently '
                         'has it.'.format(self.lock_file, pid))

--- a/cyder/base/mixins.py
+++ b/cyder/base/mixins.py
@@ -198,8 +198,8 @@ class MutexMixin(object):
             # IOError: [Errno 2] No such file or directory
             if exc_value[0] == 2:
                 self.error(
-                    "Failed to acquire lock on {0}, but the the process that "
-                    "has it hasn't written the PID file {1} yet.".format(
+                    "Failed to acquire lock on {0}, but the process that has "
+                    "it hasn't written the PID file ({1}) yet.".format(
                         self.lock_file, self.pid_file))
             else:
                 raise

--- a/cyder/base/utils.py
+++ b/cyder/base/utils.py
@@ -57,6 +57,8 @@ class Logger(object):
 
 def run_command(command, logger=Logger(), ignore_failure=False,
                 failure_msg=None):
+    # A single default Logger instance is shared between every call to this
+    # function. Keep that in mind if you give Logger more state.
     logger.log_debug('Calling `{0}` in {1}'.format(command, os.getcwd()))
     out, err, returncode = shell_out(command)
     if returncode != 0 and not ignore_failure:
@@ -68,7 +70,7 @@ def run_command(command, logger=Logger(), ignore_failure=False,
         if err:
             msg += '=== stderr ===\n{0}\n'.format(err)
         msg = msg.rstrip('\n') + '\n'
-        error(msg)
+        logger.error(msg)
     return out, err, returncode
 
 

--- a/cyder/base/utils.py
+++ b/cyder/base/utils.py
@@ -36,13 +36,23 @@ def shell_out(command, use_shlex=True):
     return out, err, p.returncode
 
 
-def _error(msg):
-    raise Exception(msg)
+class Logger(object):
+    def log_debug(self, msg):
+        pass
+
+    def log_info(self, msg):
+        pass
+
+    def log_notice(self, msg):
+        pass
+
+    def error(self, msg):
+        raise Exception(msg)
 
 
-def run_command(command, log_debug=lambda msg: msg, error=_error,
-                ignore_failure=False, failure_msg=None):
-    log_debug('Calling `{0}` in {1}'.format(command, os.getcwd()))
+def run_command(command, logger=Logger(), ignore_failure=False,
+                failure_msg=None):
+    logger.log_debug('Calling `{0}` in {1}'.format(command, os.getcwd()))
     out, err, returncode = shell_out(command)
     if returncode != 0 and not ignore_failure:
         msg = '{}: '.format(failure_msg) if failure_msg else ''

--- a/cyder/base/utils.py
+++ b/cyder/base/utils.py
@@ -37,6 +37,11 @@ def shell_out(command, use_shlex=True):
 
 
 class Logger(object):
+    """
+    A Logger logs messages passed to it. Possible destinations include stderr
+    and the system journal (syslog).
+    """
+
     def log_debug(self, msg):
         pass
 

--- a/cyder/base/vcs.py
+++ b/cyder/base/vcs.py
@@ -44,12 +44,13 @@ class VCSRepo(object):
 
     def __init__(self, repo_dir, line_change_limit=None,
                  line_removal_limit=None, log_debug=lambda msg: msg,
-                 error=lambda msg: msg):
+                 log_info=lambda msg: msg, error=lambda msg: msg):
         set_attrs(self, {
             'repo_dir': repo_dir,
             'line_change_limit': line_change_limit,
             'line_removal_limit': line_removal_limit,
             'log_debug': log_debug,
+            'log_info': log_info,
             'error': error,
         })
 
@@ -107,8 +108,7 @@ class GitRepo(VCSRepo):
             self._add_all()
 
         if not self._is_index_dirty() and not empty:
-            self.log_debug('There were no changes. Nothing to commit.',
-                      log_level='LOG_INFO')
+            self.log_info('There were no changes. Nothing to commit.')
             return
 
         if sanity_check:

--- a/cyder/base/vcs.py
+++ b/cyder/base/vcs.py
@@ -1,28 +1,12 @@
 import os
 import re
-import syslog
 from os.path import dirname, basename
 
-from cyder.base.utils import set_attrs, dict_merge, log, run_command
+from cyder.base.utils import set_attrs, dict_merge, run_command
 
 
-def _log(self, message, log_level='LOG_DEBUG'):
-    log(message, log_level=log_level, to_stderr=self.debug,
-            to_syslog=self.log_syslog, logger=self.logger)
-
-
-def _run_command(self, command, log=True, failure_msg=None,
-                 ignore_failure=False):
-    if log:
-        command_logger = self._log
-        failure_logger = lambda msg: self._log(msg, log_level='LOG_ERR')
-    else:
-        command_logger, failure_logger = None, None
-
-    return run_command(
-        command, command_logger=command_logger,
-        failure_logger=failure_logger, failure_msg=failure_msg,
-        ignore_failure=ignore_failure)
+def _error(msg):
+    raise Exception(msg)
 
 
 class SanityCheckFailure(Exception):
@@ -54,20 +38,19 @@ def repo_chdir_wrapper(func):
 
 
 class VCSRepo(object):
-    _run_command = _run_command
-
-    _log = _log
+    def _run_command(self, command, ignore_failure=False):
+        return run_command(command, log_debug=self.log_debug, error=self.error,
+                           ignore_failure=ignore_failure)
 
     def __init__(self, repo_dir, line_change_limit=None,
-                 line_removal_limit=None, debug=False, log_syslog=False,
-                 logger=syslog):
+                 line_removal_limit=None, log_debug=lambda msg: msg,
+                 error=lambda msg: msg):
         set_attrs(self, {
             'repo_dir': repo_dir,
             'line_change_limit': line_change_limit,
             'line_removal_limit': line_removal_limit,
-            'debug': debug,
-            'log_syslog': log_syslog,
-            'logger': logger,
+            'log_debug': log_debug,
+            'error': error,
         })
 
     @repo_chdir_wrapper
@@ -77,7 +60,6 @@ class VCSRepo(object):
     @repo_chdir_wrapper
     def reset_and_pull(self):
         """Make the working tree match what's currently upstream."""
-
         self._reset_to_head()
         self._pull()
 
@@ -125,15 +107,15 @@ class GitRepo(VCSRepo):
             self._add_all()
 
         if not self._is_index_dirty() and not empty:
-            self._log('There were no changes. Nothing to commit.',
+            self.log_debug('There were no changes. Nothing to commit.',
                       log_level='LOG_INFO')
             return
 
         if sanity_check:
             self._sanity_check()
         else:
-            self._log('Skipping sanity check because sanity_check=False was '
-                      'passed.')
+            self.log_debug(
+                'Skipping sanity check because sanity_check=False was passed.')
 
         self._commit(message, allow_empty=empty)
         self._push()
@@ -152,10 +134,9 @@ class GitRepo(VCSRepo):
         self._run_command('git add -A .')
 
     def _lines_changed(self):
-        diff_ignore = (re.compile(r'--- \S'),
-                       re.compile(r'\+\+\+ \S'))
+        diff_ignore = (re.compile(r'--- \S'), re.compile(r'\+\+\+ \S'))
 
-        output, _, _ = self._run_command('git diff --cached', log=False)
+        output, _, _ = self._run_command('git diff --cached')
 
         added, removed = 0, 0
         for line in output.split('\n'):
@@ -169,8 +150,8 @@ class GitRepo(VCSRepo):
         return added, removed
 
     def _commit(self, message, allow_empty=False):
-        cmd = ('git commit ' + ('--allow-empty ' if allow_empty else '') +
-               '-m "{0}"'.format(message))
+        cmd = ('git commit' + (' --allow-empty' if allow_empty else '') +
+               ' -m "{0}"'.format(message))
         self._run_command(cmd)
 
     def _push(self):
@@ -178,25 +159,21 @@ class GitRepo(VCSRepo):
 
 
 class VCSRepoManager(object):
-    _run_command = _run_command
+    def __init__(self, log_debug=lambda msg: msg, error=_error):
+        self.log_debug = log_debug
+        self.error = error
 
-    def __init__(self, debug=False, log_syslog=False, logger=syslog):
-        set_attrs(self, {
-            'debug': debug,
-            'log_syslog': log_syslog,
-            'logger': logger,
-        })
+    def _run_command(self, command, ignore_failure=False):
+        return run_command(command, log_debug=self.log_debug, error=self.error,
+                           ignore_failure=ignore_failure)
 
     def open(self, *args, **kwargs):
         return VCSRepo(*args, **kwargs)
 
 
 class GitRepoManager(VCSRepoManager):
-    _log = _log
-
-    def __init__(self, **kwargs):
-        self.config = kwargs.pop('config', {})
-        super(GitRepoManager, self).__init__(**kwargs)
+    def __init__(self, config):
+        self.config = config
 
     def open(self, *args, **kwargs):
         return GitRepo(*args, **kwargs)

--- a/cyder/cydhcp/build/builder.py
+++ b/cyder/cydhcp/build/builder.py
@@ -10,7 +10,7 @@ from traceback import format_exception
 
 from cyder.base.mixins import MutexMixin
 from cyder.base.utils import (
-    copy_tree, dict_merge, run_command, set_attrs, shell_out)
+    copy_tree, dict_merge, Logger, run_command, set_attrs, shell_out)
 from cyder.base.vcs import GitRepo
 
 from cyder.core.utils import fail_mail
@@ -22,7 +22,7 @@ from cyder.cydhcp.workgroup.models import Workgroup
 from cyder.settings import DHCPBUILD
 
 
-class DHCPBuilder(MutexMixin):
+class DHCPBuilder(MutexMixin, Logger):
     def __init__(self, *args, **kwargs):
         kwargs = dict_merge(DHCPBUILD, {
             'quiet': False,
@@ -33,7 +33,7 @@ class DHCPBuilder(MutexMixin):
 
         self.repo = GitRepo(
             self.prod_dir, self.line_change_limit, self.line_removal_limit,
-            log_debug=self.log_debug, log_info=self.log_info, error=self.error)
+            logger=self)
 
     def log(self, log_level, msg):
         if self.to_syslog:

--- a/cyder/cydhcp/build/builder.py
+++ b/cyder/cydhcp/build/builder.py
@@ -9,8 +9,8 @@ import time
 from traceback import format_exception
 
 from cyder.base.mixins import MutexMixin
-from cyder.base.utils import (copy_tree, dict_merge, log, run_command,
-                              set_attrs, shell_out)
+from cyder.base.utils import (
+    copy_tree, dict_merge, run_command, set_attrs, shell_out)
 from cyder.base.vcs import GitRepo
 
 from cyder.core.utils import fail_mail
@@ -25,39 +25,39 @@ from cyder.settings import DHCPBUILD
 class DHCPBuilder(MutexMixin):
     def __init__(self, *args, **kwargs):
         kwargs = dict_merge(DHCPBUILD, {
-            'verbose': True,
-            'debug': False,
+            'quiet': False,
+            'verbose': False,
+            'to_syslog': False,
         }, kwargs)
         set_attrs(self, kwargs)
 
-        if self.log_syslog:
-            syslog.openlog(b'dhcp_build', 0, syslog.LOG_LOCAL6)
+        self.repo = GitRepo(
+            self.prod_dir, self.line_change_limit, self.line_removal_limit,
+            log_debug=self.log_debug, log_info=self.log_info, error=self.error)
 
-        self.repo = GitRepo(self.prod_dir, self.line_change_limit,
-            self.line_removal_limit, debug=self.debug,
-            log_syslog=self.log_syslog, logger=syslog)
+    def log(self, log_level, msg):
+        if self.to_syslog:
+            for line in msg.splitlines():
+                syslog.syslog(log_level, line)
 
-    def log_debug(self, msg, to_stderr=None):
-        if to_stderr is None:
-            to_stderr = self.debug
-        log(msg, log_level='LOG_DEBUG', to_syslog=False, to_stderr=to_stderr,
-                logger=syslog)
+    def log_debug(self, msg):
+        self.log(syslog.LOG_DEBUG, msg)
+        if self.verbose:
+            print msg
 
-    def log_info(self, msg, to_stderr=None):
-        if to_stderr is None:
-            to_stderr = self.verbose
-        log(msg, log_level='LOG_INFO', to_syslog=self.log_syslog,
-                to_stderr=to_stderr, logger=syslog)
+    def log_info(self, msg):
+        self.log(syslog.LOG_INFO, msg)
+        if not self.quiet:
+            print msg
 
-    def log_notice(self, msg, to_stderr=None):
-        if to_stderr is None:
-            to_stderr = self.verbose
-        log(msg, log_level='LOG_NOTICE', to_syslog=self.log_syslog,
-                to_stderr=to_stderr, logger=syslog)
+    def log_notice(self, msg):
+        self.log(syslog.LOG_NOTICE, msg)
+        if not self.quiet:
+            print msg
 
-    def log_err(self, msg, to_stderr=True):
-        log(msg, log_level='LOG_ERR', to_syslog=self.log_syslog,
-                to_stderr=to_stderr, logger=syslog)
+    def error(self, msg):
+        self.log(syslog.LOG_ERR, msg)
+        raise Exception(msg)
 
     def run_command(self, command, log=True, failure_msg=None):
         if log:
@@ -108,7 +108,9 @@ class DHCPBuilder(MutexMixin):
                 for workgroup in Workgroup.objects.all():
                     f.write(workgroup.build_workgroup())
         except:
-            self.error()
+            self.log(syslog.LOG_ERR,
+                'DHCP build failed.\nOriginal exception: ' + e.message)
+            raise
 
         if self.check_file:
             self.check_syntax()

--- a/cyder/cydhcp/build/tests/build_tests.py
+++ b/cyder/cydhcp/build/tests/build_tests.py
@@ -25,7 +25,6 @@ DHCPBUILD = {
     'line_removal_limit': None,
     'stop_file': '/tmp/cyder_dhcp_test.stop',
     'stop_file_email_interval': None,  # never
-    'log_syslog': False,
 }
 
 PROD_ORIGIN_DIR = '/tmp/cyder_dhcp_test/prod_origin'
@@ -46,7 +45,7 @@ class DHCPBuildTest(TestCase):
             os.makedirs(PROD_ORIGIN_DIR)
         remove_dir_contents(PROD_ORIGIN_DIR)
 
-        mgr = GitRepoManager(debug=False, log_syslog=False, config={
+        mgr = GitRepoManager(config={
             'user.name': 'test',
             'user.email': 'test',
         })

--- a/cyder/cydhcp/range/models.py
+++ b/cyder/cydhcp/range/models.py
@@ -30,7 +30,7 @@ import ipaddr
 class Range(BaseModel, ViewMixin, ObjectUrlMixin):
     """
     Ranges live inside networks; their start ip address is greater than or
-    equal to the the start of their network and their end ip address is less
+    equal to the start of their network and their end ip address is less
     than or equal to the end of their network; both the Range and the network
     class enforce these requirements. Good practice says ranges should not
     start on the network address of their network and they should not end on

--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -30,20 +30,21 @@ class DNSBuilder(MutexMixin):
         kwargs = dict_merge(BINDBUILD, {
             'quiet': False,
             'verbose': False,
-            'logger': lambda log_level, msg: None,
+            'to_syslog': False,
         }, kwargs)
         set_attrs(self, kwargs)
 
         self.repo = GitRepo(
             self.prod_dir, self.line_change_limit,
             self.line_removal_limit, log_debug=self.log_debug,
-            error=self.error)
+            log_info=self.log_info, error=self.error)
 
     def log(self, log_level, msg, root_domain=None):
         if root_domain:
             msg = '< {} > {}'.format(root_domain.name, msg)
-        for line in msg.splitlines():
-            self.logger(log_level, line)
+        if self.to_syslog:
+            for line in msg.splitlines():
+                syslog.syslog(log_level, line)
         return msg
 
     def log_debug(self, msg, root_domain=None):

--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -172,8 +172,8 @@ class DNSBuilder(MutexMixin, Logger):
 
     def build_zone(self, view, file_meta, view_data, root_domain):
         """
-        This function will write the zone's zone file to the the staging area
-        and call named-checkconf on the files.
+        This function will write the zone's zone file to the staging area and
+        call named-checkconf on the files.
         """
         stage_fname = os.path.join(self.stage_dir, file_meta['rel_fname'])
         self.write_stage_zone(

--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -77,7 +77,7 @@ class DNSBuilder(MutexMixin):
         during the next build.
 
         If the build is successful we will delete all the scheduled tasks
-        return by this function
+        returned by this function.
 
         note::
             When we are not checking files into Git we do not need to delete

--- a/cyder/cydns/cybind/builder.py
+++ b/cyder/cydns/cybind/builder.py
@@ -10,8 +10,8 @@ from traceback import format_exception
 from cyder.settings import BINDBUILD, ZONES_WITH_NO_CONFIG
 
 from cyder.base.mixins import MutexMixin
-from cyder.base.utils import (copy_tree, dict_merge, remove_dir_contents,
-                              run_command, set_attrs)
+from cyder.base.utils import (
+    copy_tree, dict_merge, Logger, remove_dir_contents, run_command, set_attrs)
 from cyder.base.vcs import GitRepo
 
 from cyder.core.task.models import Task
@@ -24,7 +24,7 @@ from cyder.cydns.cybind.models import DNSBuildRun
 from cyder.cydns.cybind.serial_utils import get_serial
 
 
-class DNSBuilder(MutexMixin):
+class DNSBuilder(MutexMixin, Logger):
     def __init__(self, **kwargs):
         kwargs = dict_merge(BINDBUILD, {
             'quiet': False,
@@ -35,7 +35,7 @@ class DNSBuilder(MutexMixin):
 
         self.repo = GitRepo(
             self.prod_dir, self.line_change_limit, self.line_removal_limit,
-            log_debug=self.log_debug, log_info=self.log_info, error=self.error)
+            logger=self)
 
     def log(self, log_level, msg, root_domain=None):
         if root_domain:
@@ -65,8 +65,7 @@ class DNSBuilder(MutexMixin):
         raise Exception(msg)
 
     def run_command(self, command, failure_msg=None):
-        return run_command(command, log_debug=self.log_debug, error=self.error,
-                           failure_msg=failure_msg)
+        return run_command(command, logger=self, failure_msg=failure_msg)
 
     def get_scheduled(self):
         """

--- a/cyder/cydns/cybind/tests/build_tests.py
+++ b/cyder/cydns/cybind/tests/build_tests.py
@@ -48,7 +48,7 @@ class DNSBuildTest(TestCase):
             os.makedirs(PROD_ORIGIN_DIR)
         remove_dir_contents(PROD_ORIGIN_DIR)
 
-        mgr = GitRepoManager(debug=False, log_syslog=False, config={
+        mgr = GitRepoManager(config={
             'user.name': 'test',
             'user.email': 'test',
         })

--- a/cyder/management/commands/bindbuild.py
+++ b/cyder/management/commands/bindbuild.py
@@ -42,14 +42,11 @@ class Command(BaseCommand):
 
         if options['to_syslog']:
             syslog.openlog(b'bindbuild', 0, syslog.LOG_LOCAL6)
+            builder_opts['to_syslog'] = True
 
         verbosity = int(options['verbosity'])
-        if verbosity is None:
-            builder_opts['quiet'] = False
-            builder_opts['verbose'] = False
-        else:
-            builder_opts['quiet'] = verbosity == 0
-            builder_opts['verbose'] = verbosity >= 2
+        builder_opts['quiet'] = verbosity == 0
+        builder_opts['verbose'] = verbosity >= 2
 
         with DNSBuilder(**builder_opts) as b:
             b.build(force=options['force_build'])

--- a/cyder/management/commands/bindbuild.py
+++ b/cyder/management/commands/bindbuild.py
@@ -44,12 +44,12 @@ class Command(BaseCommand):
             syslog.openlog(b'bindbuild', 0, syslog.LOG_LOCAL6)
 
         verbosity = int(options['verbosity'])
-        if verbosity:
+        if verbosity is None:
+            builder_opts['quiet'] = False
+            builder_opts['verbose'] = False
+        else:
             builder_opts['quiet'] = verbosity == 0
             builder_opts['verbose'] = verbosity >= 2
-        else:
-            builder_opts['quiet'] = False
-            builder_opts['verbose'] = True
 
         with DNSBuilder(**builder_opts) as b:
             b.build(force=options['force_build'])

--- a/cyder/management/commands/bindbuild.py
+++ b/cyder/management/commands/bindbuild.py
@@ -1,3 +1,4 @@
+import syslog
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
@@ -13,16 +14,16 @@ class Command(BaseCommand):
                     dest='push',
                     action='store_true',
                     default=False,
-                    help="Check files into vcs and push upstream."),
+                    help='Check files into vcs and push upstream.'),
         ### logging/debug options ###
         make_option('-l', '--log-syslog',
                     dest='log_syslog',
                     action='store_true',
-                    help="Log to syslog."),
+                    help='Log to syslog.'),
         make_option('-L', '--no-log-syslog',
                     dest='log_syslog',
                     action='store_false',
-                    help="Do not log to syslog."),
+                    help="Don't log to syslog."),
         ### miscellaneous ###
         make_option('-f', '--force-build',
                     dest='force_build',
@@ -38,18 +39,20 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         builder_opts = {}
-        for name in ('log_syslog',):
-            val = options.pop(name)
-            if val is not None:  # user specified value
-                builder_opts[name] = val
-            # else get value from settings
 
-        if options['verbosity']:
-            builder_opts['verbose'] = int(options['verbosity']) >= 1
-            builder_opts['debug'] = int(options['verbosity']) >= 2
+        if options['log_syslog']:
+            syslog.openlog(b'bindbuild', 0, syslog.LOG_LOCAL6)
+            options['logger'] = syslog.syslog
         else:
+            options['logger'] = lambda log_level, msg: None
+
+        verbosity = int(options['verbosity'])
+        if verbosity:
+            builder_opts['quiet'] = verbosity == 0
+            builder_opts['verbose'] = verbosity >= 2
+        else:
+            builder_opts['quiet'] = False
             builder_opts['verbose'] = True
-            builder_opts['debug'] = False
 
         with DNSBuilder(**builder_opts) as b:
             b.build(force=options['force_build'])

--- a/cyder/management/commands/bindbuild.py
+++ b/cyder/management/commands/bindbuild.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         builder_opts = {}
 
         if options['to_syslog']:
-            syslog.openlog(b'bindbuild', 0, syslog.LOG_LOCAL6)
+            syslog.openlog('bindbuild', facility=syslog.LOG_LOCAL6)
             builder_opts['to_syslog'] = True
 
         verbosity = int(options['verbosity'])

--- a/cyder/management/commands/bindbuild.py
+++ b/cyder/management/commands/bindbuild.py
@@ -16,12 +16,12 @@ class Command(BaseCommand):
                     default=False,
                     help='Check files into vcs and push upstream.'),
         ### logging/debug options ###
-        make_option('-l', '--log-syslog',
-                    dest='log_syslog',
+        make_option('-l', '--syslog',
+                    dest='to_syslog',
                     action='store_true',
                     help='Log to syslog.'),
-        make_option('-L', '--no-log-syslog',
-                    dest='log_syslog',
+        make_option('-L', '--no-syslog',
+                    dest='to_syslog',
                     action='store_false',
                     help="Don't log to syslog."),
         ### miscellaneous ###
@@ -40,11 +40,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         builder_opts = {}
 
-        if options['log_syslog']:
+        if options['to_syslog']:
             syslog.openlog(b'bindbuild', 0, syslog.LOG_LOCAL6)
-            options['logger'] = syslog.syslog
-        else:
-            options['logger'] = lambda log_level, msg: None
 
         verbosity = int(options['verbosity'])
         if verbosity:

--- a/cyder/management/commands/dhcp_build.py
+++ b/cyder/management/commands/dhcp_build.py
@@ -14,12 +14,12 @@ class Command(BaseCommand):
                     default=False,
                     help="Check files into vcs and push upstream."),
         ### logging/debug options ###
-        make_option('-l', '--log-syslog',
-                    dest='log_syslog',
+        make_option('-l', '--syslog',
+                    dest='to_syslog',
                     action='store_true',
                     help="Log to syslog."),
-        make_option('-L', '--no-log-syslog',
-                    dest='log_syslog',
+        make_option('-L', '--no-syslog',
+                    dest='to_syslog',
                     action='store_false',
                     help="Do not log to syslog."),
         ### miscellaneous ###
@@ -32,18 +32,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         builder_opts = {}
-        for name in ('log_syslog',):
-            val = options.pop(name)
-            if val is not None:  # user specified value
-                builder_opts[name] = val
-            # else get value from settings
 
-        if options['verbosity']:
-            builder_opts['verbose'] = int(options['verbosity']) >= 1
-            builder_opts['debug'] = int(options['verbosity']) >= 2
-        else:
-            builder_opts['verbose'] = True
-            builder_opts['debug'] = False
+        if options['to_syslog']:
+            syslog.openlog(b'dhcp_build', 0, syslog.LOG_LOCAL6)
+            builder_opts['to_syslog'] = True
+
+        verbosity = int(options['verbosity'])
+        builder_opts['quiet'] = verbosity == 0
+        builder_opts['verbose'] = verbosity >= 2
 
         with DHCPBuilder(**builder_opts) as b:
             b.build()

--- a/cyder/management/commands/dhcp_build.py
+++ b/cyder/management/commands/dhcp_build.py
@@ -1,3 +1,4 @@
+import syslog
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError

--- a/cyder/management/commands/dhcp_build.py
+++ b/cyder/management/commands/dhcp_build.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         builder_opts = {}
 
         if options['to_syslog']:
-            syslog.openlog(b'dhcp_build', 0, syslog.LOG_LOCAL6)
+            syslog.openlog('dhcp_build', facility=syslog.LOG_LOCAL6)
             builder_opts['to_syslog'] = True
 
         verbosity = int(options['verbosity'])


### PR DESCRIPTION
**Resolves issue #593.**

---

- [x] Add `Logger` interface (providing `log_debug`, `log_info`, etc.) and pass instances around instead of the functions themselves.