### PR TITLE
Implement and test `Network.children`

### DIFF
--- a/cyder/cydhcp/network/models.py
+++ b/cyder/cydhcp/network/models.py
@@ -270,8 +270,7 @@ class Network(BaseModel, ObjectUrlMixin):
                                   .format(self.ip_type, e))
         # Update fields
         self.ip_upper = int(self.network) >> 64
-        self.ip_lower = int(self.network) & (1 << 64) - 1  # Mask off
-                                                    # the last sixty-four bits
+        self.ip_lower = int(self.network) & (1 << 64) - 1
         self.prefixlen = self.network.prefixlen
         self.network_str = str(self.network)
 
@@ -286,6 +285,16 @@ class Network(BaseModel, ObjectUrlMixin):
         elif self.ip_type == '6':
             raise Exception(
                 'Network.descendants does not currently support IPv6')
+
+    @property
+    def children(self):
+        self.update_network()
+        descendants = set(self.descendants)
+        children = []
+        for d in descendants:
+            if d.parent not in descendants:
+                children.append(d)
+        return children
 
     @property
     def parent(self):

--- a/cyder/cydhcp/network/models.py
+++ b/cyder/cydhcp/network/models.py
@@ -292,7 +292,7 @@ class Network(BaseModel, ObjectUrlMixin):
         descendants = set(self.descendants)
         children = []
         for d in descendants:
-            if d.parent not in descendants:
+            if d.parent == self:
                 children.append(d)
         return children
 

--- a/cyder/cydhcp/network/models.py
+++ b/cyder/cydhcp/network/models.py
@@ -289,9 +289,8 @@ class Network(BaseModel, ObjectUrlMixin):
     @property
     def children(self):
         self.update_network()
-        descendants = set(self.descendants)
         children = []
-        for d in descendants:
+        for d in self.descendants:
             if d.parent == self:
                 children.append(d)
         return children

--- a/cyder/cydhcp/network/tests.py
+++ b/cyder/cydhcp/network/tests.py
@@ -99,8 +99,7 @@ class NetworkTests(TestCase, ModelTestMixin):
         if we choose s3 then n2, n3, and n4 should be returned
         """
 
-    def test_parent_children(self):
-        raise SkipTest
+    def test_parent_children_descendants(self):
         n1 = Network.objects.create(network_str='10.0.0.0/8')
         n2 = Network.objects.create(network_str='10.0.0.0/14')
         n3 = Network.objects.create(network_str='10.1.0.0/16')
@@ -119,8 +118,15 @@ class NetworkTests(TestCase, ModelTestMixin):
         self.assertEqual(set(n2.children), {n3, n6})
         self.assertEqual(set(n3.children), {n4})
         self.assertEqual(set(n4.children), {n5})
-        self.assertEqual(set(n5.children), {})
-        self.assertEqual(set(n6.children), {})
+        self.assertEqual(set(n5.children), set())
+        self.assertEqual(set(n6.children), set())
+
+        self.assertEqual(set(n1.descendants), {n2, n3, n4, n5, n6})
+        self.assertEqual(set(n2.descendants), {n3, n4, n5, n6})
+        self.assertEqual(set(n3.descendants), {n4, n5})
+        self.assertEqual(set(n4.descendants), {n5})
+        self.assertEqual(set(n5.descendants), set())
+        self.assertEqual(set(n6.descendants), set())
 
     def test_check_valid_ranges_v4_valid(self):
         n = Network(network_str='10.0.0.0/8')


### PR DESCRIPTION
**Resolves issue #760.**

This is mostly for debugging, but eventually we might want to show a network's children on network detail pages.