### PR TITLE
Unwrap the 1-tuple in fix_maintain

### DIFF
--- a/cyder/management/commands/lib/fix_maintain.py
+++ b/cyder/management/commands/lib/fix_maintain.py
@@ -40,7 +40,7 @@ def main():
     print 'Fixing domains...'
     cursor.execute("SELECT name FROM domain")
 
-    for name in cursor.fetchall():
+    for (name,) in cursor.fetchall():
         if '.in-addr.arpa' in name or name in ('', ' ', '.'):
             continue
         fix_domain(name)


### PR DESCRIPTION
This will cause `fix_maintain` to work as it originally did, and migrate TLDs.