### PR TITLE
Fix default workgroup

### DIFF
--- a/cyder/cydhcp/constants.py
+++ b/cyder/cydhcp/constants.py
@@ -21,3 +21,5 @@ RANGE_TYPE = (
 DHCP_EAV_MODELS = ("static_interface_av", "dynamic_interface_av", "range_av",
                    "network_av", "workgroup_av", "vlan_av", "vrf_av",
                    "site_av")
+
+DEFAULT_WORKGROUP = 1

--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -13,6 +13,7 @@ from cyder.base.models import BaseModel, ExpirableMixin
 from cyder.base.utils import transaction_atomic
 from cyder.core.ctnr.models import Ctnr
 from cyder.core.system.models import System
+from cyder.cydhcp.constants import DEFAULT_WORKGROUP
 from cyder.cydhcp.interface.dynamic_intr.validation import is_dynamic_range
 from cyder.cydhcp.range.models import Range
 from cyder.cydhcp.utils import format_mac, join_dhcp_args
@@ -23,9 +24,8 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
     pretty_type = 'dynamic interface'
 
     ctnr = models.ForeignKey(Ctnr, null=False, verbose_name="Container")
-    workgroup = models.ForeignKey(
-        Workgroup, null=False, blank=False,
-        default=Workgroup.objects.get(name='default'))
+    workgroup = models.ForeignKey(Workgroup, null=False, blank=False,
+                                  default=DEFAULT_WORKGROUP)
     system = models.ForeignKey(System, help_text="System to associate "
                                                  "the interface with")
     mac = MacAddrField(dhcp_enabled='dhcp_enabled', verbose_name='MAC address',

--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -23,7 +23,7 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
     pretty_type = 'dynamic interface'
 
     ctnr = models.ForeignKey(Ctnr, null=False, verbose_name="Container")
-    workgroup = models.ForeignKey(Workgroup, null=True, blank=True)
+    workgroup = models.ForeignKey(Workgroup, null=False, blank=False)
     system = models.ForeignKey(System, help_text="System to associate "
                                                  "the interface with")
     mac = MacAddrField(dhcp_enabled='dhcp_enabled', verbose_name='MAC address',

--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -23,7 +23,9 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
     pretty_type = 'dynamic interface'
 
     ctnr = models.ForeignKey(Ctnr, null=False, verbose_name="Container")
-    workgroup = models.ForeignKey(Workgroup, null=False, blank=False)
+    workgroup = models.ForeignKey(
+        Workgroup, null=False, blank=False,
+        default=Workgroup.objects.get(name='default'))
     system = models.ForeignKey(System, help_text="System to associate "
                                                  "the interface with")
     mac = MacAddrField(dhcp_enabled='dhcp_enabled', verbose_name='MAC address',

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -15,7 +15,7 @@ from cyder.base.fields import MacAddrField
 from cyder.base.models import ExpirableMixin
 from cyder.base.utils import transaction_atomic
 from cyder.core.system.models import System
-from cyder.cydhcp.constants import STATIC
+from cyder.cydhcp.constants import STATIC, DEFAULT_WORKGROUP
 from cyder.cydhcp.range.utils import find_range
 from cyder.cydhcp.utils import format_mac, join_dhcp_args
 from cyder.cydhcp.workgroup.models import Workgroup
@@ -59,9 +59,8 @@ class StaticInterface(BaseAddressRecord, BasePTR, ExpirableMixin):
     system = models.ForeignKey(
         System, help_text='System to associate the interface with')
 
-    workgroup = models.ForeignKey(
-        Workgroup, null=False, blank=False,
-        default=Workgroup.objects.get(name='default'))
+    workgroup = models.ForeignKey(Workgroup, null=False, blank=False,
+                                  default=DEFAULT_WORKGROUP)
 
     dhcp_enabled = models.BooleanField(verbose_name='Enable DHCP?',
                                        default=True)

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -59,7 +59,7 @@ class StaticInterface(BaseAddressRecord, BasePTR, ExpirableMixin):
     system = models.ForeignKey(
         System, help_text='System to associate the interface with')
 
-    workgroup = models.ForeignKey(Workgroup, null=True, blank=True)
+    workgroup = models.ForeignKey(Workgroup, null=False, blank=False)
 
     dhcp_enabled = models.BooleanField(verbose_name='Enable DHCP?',
                                        default=True)

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -59,7 +59,9 @@ class StaticInterface(BaseAddressRecord, BasePTR, ExpirableMixin):
     system = models.ForeignKey(
         System, help_text='System to associate the interface with')
 
-    workgroup = models.ForeignKey(Workgroup, null=False, blank=False)
+    workgroup = models.ForeignKey(
+        Workgroup, null=False, blank=False,
+        default=Workgroup.objects.get(name='default'))
 
     dhcp_enabled = models.BooleanField(verbose_name='Enable DHCP?',
                                        default=True)

--- a/cyder/cydhcp/workgroup/models.py
+++ b/cyder/cydhcp/workgroup/models.py
@@ -1,6 +1,7 @@
 from itertools import chain
 
 from django.db import models
+from django.db.models import Q
 
 from cyder.base.eav.constants import ATTRIBUTE_OPTION, ATTRIBUTE_STATEMENT
 from cyder.base.eav.fields import EAVAttributeField
@@ -27,10 +28,11 @@ class Workgroup(BaseModel, ObjectUrlMixin):
 
     @staticmethod
     def filter_by_ctnr(ctnr, objects=None):
-        if objects:
-            return ctnr.workgroups.filter(pk__in=objects)
-        else:
-            return ctnr.workgroups
+        workgroups = Workgroup.objects.filter(Q(id__in=ctnr.workgroups.all()) |
+                                              Q(name="default"))
+        if objects is not None:
+            workgroups = workgroups.filter(pk__in=objects)
+        return workgroups
 
     def details(self):
         data = super(Workgroup, self).details()

--- a/cyder/fixtures/dhcp_build_test.json
+++ b/cyder/fixtures/dhcp_build_test.json
@@ -316,7 +316,7 @@
   "pk": 1,
   "model": "cyder.dynamicinterface",
   "fields": {
-   "workgroup": null,
+   "workgroup": 1,
    "created": "2014-02-08T14:22:23",
    "system": 1,
    "modified": "2014-02-08T14:30:46",

--- a/cyder/fixtures/dns_build_test.json
+++ b/cyder/fixtures/dns_build_test.json
@@ -181,6 +181,7 @@
   "pk": 1,
   "model": "cyder.staticinterface",
   "fields": {
+   "workgroup": 1,
    "system": 1,
    "dns_enabled": true,
    "domain": 5,
@@ -201,7 +202,7 @@
    "ip_str": "192.168.0.30",
    "last_seen": "2014-02-01T12:06:20",
    "reverse_domain": 3,
-   "workgroup": null,
+   "workgroup": 1,
    "ctnr": 3,
    "description": ""
   }
@@ -210,6 +211,7 @@
   "pk": 2,
   "model": "cyder.staticinterface",
   "fields": {
+   "workgroup": 1,
    "system": 1,
    "dns_enabled": true,
    "domain": 5,
@@ -230,7 +232,7 @@
    "ip_str": "192.168.0.30",
    "last_seen": "2014-02-01T12:06:20",
    "reverse_domain": 3,
-   "workgroup": null,
+   "workgroup": 1,
    "ctnr": 3,
    "description": ""
   }
@@ -239,6 +241,7 @@
   "pk": 3,
   "model": "cyder.staticinterface",
   "fields": {
+   "workgroup": 1,
    "system": 1,
    "dns_enabled": true,
    "domain": 5,
@@ -259,7 +262,7 @@
    "ip_str": "192.168.0.3",
    "last_seen": "2014-02-01T11:55:57",
    "reverse_domain": 3,
-   "workgroup": null,
+   "workgroup": 1,
    "ctnr": 3,
    "description": ""
   }
@@ -268,6 +271,7 @@
   "pk": 4,
   "model": "cyder.staticinterface",
   "fields": {
+   "workgroup": 1,
    "system": 2,
    "dns_enabled": true,
    "domain": 7,
@@ -288,7 +292,7 @@
    "ip_str": "192.168.0.21",
    "last_seen": "2014-02-01T12:15:42",
    "reverse_domain": 3,
-   "workgroup": null,
+   "workgroup": 1,
    "ctnr": 3,
    "description": ""
   }

--- a/cyder/management/commands/dns_migrate.py
+++ b/cyder/management/commands/dns_migrate.py
@@ -319,7 +319,7 @@ class Zone(object):
                 wname = cursor.fetchone()[0]
                 w, _ = Workgroup.objects.get_or_create(name=wname)
             else:
-                w = None
+                w = Workgroup.objects.get(name="default")
 
             last_seen = items['last_seen'] or None
             if last_seen:


### PR DESCRIPTION
This pull request adds the default workgroup to every interface's dropdown, and makes the workgroup field non-nullable. It does NOT force containers for workgroups and interfaces to match. Partially resolves https://github.com/OSU-Net/cyder/issues/841