### PR TITLE
Change dynamic interface hostnames

### DIFF
--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -105,10 +105,9 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
         return related_systems
 
     def get_fqdn(self):
-        if not self.system.name:
-            return self.range.domain.name
-        else:
-            return "{0}.{1}".format(self.system.name, self.range.domain.name)
+        return (
+            self.mac.replace(':', '') + '-' + str(self.range.pk) + '.' +
+            self.range.domain.name)
 
     def clean(self, *args, **kwargs):
         super(DynamicInterface, self).clean(*args, **kwargs)


### PR DESCRIPTION
**Resolves issues #543, #672, and #806. Supersedes PR #635.**

This pull request changes how we build host declarations for dynamic interfaces. Using the interface's system's name as the first label of the hostname is bad, so I changed it so the first label contains the MAC address and the range's primary key.