### PR TITLE
Restrict VRF names to letters, numbers, hyphens, and underscores

### DIFF
--- a/cyder/cydhcp/vrf/models.py
+++ b/cyder/cydhcp/vrf/models.py
@@ -8,13 +8,15 @@ from cyder.base.eav.models import Attribute, EAVBase
 from cyder.base.mixins import ObjectUrlMixin
 from cyder.base.models import BaseModel
 from cyder.base.utils import transaction_atomic
+from cyder.cydhcp.vrf.validators import validate_vrf_name
 
 
 class Vrf(BaseModel, ObjectUrlMixin):
     pretty_type = 'VRF'
 
     id = models.AutoField(primary_key=True)
-    name = models.CharField(max_length=100, unique=True)
+    name = models.CharField(
+        max_length=100, unique=True, validators=[validate_vrf_name])
 
     search_fields = ('name',)
     sort_fields = ('name',)

--- a/cyder/cydhcp/vrf/tests.py
+++ b/cyder/cydhcp/vrf/tests.py
@@ -9,5 +9,6 @@ class VrfTests(TestCase, ModelTestMixin):
         return (
             Vrf.objects.create(name='a'),
             Vrf.objects.create(name='bbbbbbbbbbbbb'),
-            Vrf.objects.create(name='Hello, world.'),
+            Vrf.objects.create(name='-c-c-c-'),
+            Vrf.objects.create(name='__d__d__d__'),
         )

--- a/cyder/cydhcp/vrf/validators.py
+++ b/cyder/cydhcp/vrf/validators.py
@@ -1,0 +1,10 @@
+from django.core.exceptions import ValidationError
+
+
+def validate_vrf_name(name):
+    for c in name:
+        if not ('A' <= c <= 'Z' or 'a' <= c <= 'z' or '0' <= c <= '9' or
+                c in '-_'):
+            raise ValidationError(
+                'VRF name can only contain letters, numbers, hyphens, and '
+                'underscores')


### PR DESCRIPTION
**Resolves issue #871.**