### PR TITLE
Display workgroup menu item as singular rather than plural

### DIFF
--- a/cyder/templates/base/sidebar.html
+++ b/cyder/templates/base/sidebar.html
@@ -26,6 +26,6 @@
      ('site', 'Site'),
      ('vlan', 'VLAN'),
      ('vrf', 'VRF'),
-     ('workgroup', 'Workgroups')]),
+     ('workgroup', 'Workgroup')]),
   ]) }}
 


### PR DESCRIPTION
Resolves: https://github.com/OSU-Net/cyder/issues/889