### PR TITLE
Fix issue with update icon behaviour in tables

### DIFF
--- a/media/css/tables.scss
+++ b/media/css/tables.scss
@@ -20,7 +20,7 @@ table.table {
         position: relative;
         top: 2px;
     }
-    .update:hover {
+    .js-get-form:hover {
         position: relative;
         top: 2px;
     }


### PR DESCRIPTION
All other icons in tables slightly move when hovering. The update icon was underlining rather than moving.