### PR TITLE
Scroll to top of page when opening an object form

### DIFF
--- a/media/js/views.js
+++ b/media/js/views.js
@@ -115,6 +115,7 @@ $(document).ready( function() {
                 };
             }
 
+            $(document).scrollTop(0);
             $.ajax({
                 type: 'GET',
                 url: kwargs.get_url,


### PR DESCRIPTION
**Resolves issue #908.**

A side-effect is that even opening a creation form scrolls to the top, but that doesn't really matter.