### PR TITLE
Require slash in 'become user' URL

### DIFF
--- a/cyder/core/cyuser/urls.py
+++ b/cyder/core/cyuser/urls.py
@@ -13,7 +13,7 @@ urlpatterns = patterns(
     url(r'setdefaultctnr/', set_default_ctnr, name='set-default-ctnr'),
     url(r'delete/(?P<user_id>[\w\d-]+)?/$', delete, name='user-delete'),
     url(r'unbecome_user/', 'unbecome_user', name='unbecome-user'),
-    url(r'(?P<username>[\w\d-]+)?/?become_user/', 'become_user',
+    url(r'(?P<username>[\w\d-]+)?/become_user/', 'become_user',
         name='become-user'),
     url(r'(?P<pk>[\w\d-]+)?/$', 'user_detail',
         name='auth_user_profile-detail'),


### PR DESCRIPTION
**Resolves issue #882.**

Couldn't resist. It just looks dumb without the slash.