### PR TITLE
Add ttl to SOA records in builds

### DIFF
--- a/cyder/cydns/cybind/zone_builder.py
+++ b/cyder/cydns/cybind/zone_builder.py
@@ -27,9 +27,10 @@ def render_soa_only(soa, root_domain):
         'refresh': soa.refresh,
         'retry': soa.retry,
         'expire': soa.expire,
-        'minimum': soa.minimum
+        'minimum': soa.minimum,
+        'ttl': soa.ttl,
     }
-    BUILD_STR = _("{root_domain}.     IN   SOA     {primary}. {contact}. (\n"
+    BUILD_STR = _("{root_domain}.  {ttl}  IN  SOA  {primary}. {contact}. (\n"
                   "\t\t{{serial}}     ; Serial\n"
                   "\t\t{refresh}     ; Refresh\n"
                   "\t\t{retry}     ; Retry\n"


### PR DESCRIPTION
It seems like SOA records have two different ways of being built... the usual `bind_render_record`, and `zone_builder.render_soa_only`. This adds the TTL to the latter.

Resolves https://github.com/OSU-Net/cyder/issues/930