### PR TITLE
Sort interfaces, ARs, and PTRs by numeric IP, not ip_str

### DIFF
--- a/cyder/base/helpers.py
+++ b/cyder/base/helpers.py
@@ -39,7 +39,7 @@ def clean_sort_param(request):
 def do_sort(request, qs):
     """Returns an order_by string based on request GET parameters"""
     # NOTE: To sort IP addresses numerically, ip_lower is used in most cases.
-    # However, this means only the lower 32 bits of ipv6 addresses are used.
+    # However, this means only the lower 64 bits of ipv6 addresses are used.
     sort, order = clean_sort_param(request)
     if sort == "id" and hasattr(qs.model, 'eg_metadata'):
         fields = [m['name'] for m in qs.model.eg_metadata()['metadata']]

--- a/cyder/base/helpers.py
+++ b/cyder/base/helpers.py
@@ -38,17 +38,13 @@ def clean_sort_param(request):
 
 def do_sort(request, qs):
     """Returns an order_by string based on request GET parameters"""
+    # NOTE: To sort IP addresses numerically, ip_lower is used in most cases.
+    # However, this means only the lower 32 bits of ipv6 addresses are used.
     sort, order = clean_sort_param(request)
     if sort == "id" and hasattr(qs.model, 'eg_metadata'):
         fields = [m['name'] for m in qs.model.eg_metadata()['metadata']]
         if fields[0] in [f.name for f in qs.model._meta.fields]:
             sort, order = fields[0], 'asc'
-
-    if sort in ['ip_str', 'network_str']:
-        sort = 'ip_lower'
-
-    if sort == 'start_str':
-        sort = 'start_lower'
 
     if sort in [f.name for f in qs.model._meta.fields]:
         try:

--- a/cyder/cydhcp/interface/dynamic_intr/models.py
+++ b/cyder/cydhcp/interface/dynamic_intr/models.py
@@ -58,7 +58,7 @@ class DynamicInterface(BaseModel, ObjectUrlMixin, ExpirableMixin):
         data['data'] = [
             ('System', 'system', self.system),
             ('Mac', 'mac', self),
-            ('Range', 'range', self.range),
+            ('Range', 'range__start_lower', self.range),
             ('Workgroup', 'workgroup', self.workgroup),
             ('Last seen', 'last_seen', self.last_seen)]
         return data

--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -95,7 +95,7 @@ class StaticInterface(BaseAddressRecord, BasePTR, ExpirableMixin):
         data['data'] = (
             ('Name', 'fqdn', self),
             ('System', 'system', self.system),
-            ('IP', 'ip_str', str(self.ip_str)),
+            ('IP', 'ip_lower', str(self.ip_str)),
             ('MAC', 'mac', self.mac),
             ('Workgroup', 'workgroup', self.workgroup),
             ('DHCP', 'dhcp_enabled',

--- a/cyder/cydhcp/network/models.py
+++ b/cyder/cydhcp/network/models.py
@@ -53,7 +53,7 @@ class Network(BaseModel, ObjectUrlMixin):
     network = None
 
     search_fields = ('vlan__name', 'site__name', 'network_str')
-    sort_fields = ('network_str',)
+    sort_fields = ('ip_lower',)
 
     class Meta:
         app_label = 'cyder'
@@ -75,7 +75,7 @@ class Network(BaseModel, ObjectUrlMixin):
         """For tables."""
         data = super(Network, self).details()
         data['data'] = (
-            ('Network', 'network_str', self),
+            ('Network', 'ip_lower', self),
             ('Site', 'site', self.site),
             ('Vlan', 'vlan', self.vlan),
             ('Vrf', 'vrf', self.vrf),

--- a/cyder/cydhcp/range/models.py
+++ b/cyder/cydhcp/range/models.py
@@ -101,7 +101,7 @@ class Range(BaseModel, ViewMixin, ObjectUrlMixin):
     range_usage = models.IntegerField(max_length=3, null=True, blank=True)
 
     search_fields = ('start_str', 'end_str', 'name')
-    sort_fields = ('start_str', 'end_str')
+    sort_fields = ('start_lower', 'end_lower')
 
     class Meta:
         app_label = 'cyder'
@@ -180,7 +180,7 @@ class Range(BaseModel, ViewMixin, ObjectUrlMixin):
         data = super(Range, self).details()
         data['data'] = [
             ('Name', 'name', self.name),
-            ('Range', 'start_str', self.get_ip_str()),
+            ('Range', 'start_lower', self.get_ip_str()),
             ('Domain', 'domain', self.domain),
             ('Type', 'range_type',
              'static' if self.range_type == 'st' else 'dynamic'),

--- a/cyder/cydns/address_record/models.py
+++ b/cyder/cydns/address_record/models.py
@@ -20,7 +20,7 @@ class BaseAddressRecord(Ip, LabelDomainMixin, CydnsRecord):
 
     """
     search_fields = ('fqdn', 'ip_str')
-    sort_fields = ('fqdn', 'ip_str')
+    sort_fields = ('fqdn', 'ip_lower')
 
     class Meta:
         abstract = True

--- a/cyder/cydns/address_record/models.py
+++ b/cyder/cydns/address_record/models.py
@@ -187,7 +187,7 @@ class AddressRecord(BaseAddressRecord):
         data['data'] = [
             ('Label', 'label', self.label),
             ('Domain', 'domain__name', self.domain),
-            ('IP', 'ip_str', str(self.ip_str)),
+            ('IP', 'ip_lower', str(self.ip_str)),
         ]
         return data
 

--- a/cyder/cydns/ptr/models.py
+++ b/cyder/cydns/ptr/models.py
@@ -256,7 +256,7 @@ class PTR(BaseModel, BasePTR, Ip, ViewMixin, DisplayMixin, ObjectUrlMixin):
         data = super(PTR, self).details()
         data['data'] = [
             ('Target', 'fqdn', self.fqdn),
-            ('IP', 'ip_str', str(self.ip_str)),
+            ('IP', 'ip_lower', str(self.ip_str)),
         ]
         return data
 


### PR DESCRIPTION
This doesn't work for IPv6, dunno if that's really feasible without reworking how the tables sort so that they can sort on both `ip_upper` and `ip_lower`. So for IPv6 addresses, only the lower 64 bits will considered when sorting by IP address.