### PR TITLE
MAC address search fix

### DIFF
--- a/cyder/management/commands/lib/dhcpd_compare2/compare.py
+++ b/cyder/management/commands/lib/dhcpd_compare2/compare.py
@@ -1,8 +1,9 @@
 import re
 from copy import deepcopy
 from itertools import ifilter
-from parsley import makeGrammar
 from sys import argv, stderr, stdout
+
+from parsley import makeGrammar
 
 from dhcp_objects import (Statement, RangeStmt, Pool, Subnet, Class, Subclass,
                           Group, Host, ConfigFile)

--- a/cyder/search/compiler/Makefile
+++ b/cyder/search/compiler/Makefile
@@ -1,7 +1,0 @@
-all:
-	python invparse.py
-
-clean:
-	rm -f *.pyc
-	rm -f parser.out
-	rm -f parsetab.py

--- a/cyder/search/compiler/django_compile.py
+++ b/cyder/search/compiler/django_compile.py
@@ -3,13 +3,10 @@ from itertools import izip
 from parsley import wrapGrammar
 from ometa.runtime import ParseError
 
-
-from cyder.search.compiler.invdsl import ICompiler
+from cyder.search.compiler.dsl import ICompiler
 from cyder.search.compiler.invfilter import (
-    DirectiveFilter, REFilter, TextFilter, BadDirective
-)
-
-from cyder.search.compiler.invfilter import searchables
+    BadDirective, DirectiveFilter, MacAddressFilter, REFilter, searchables,
+    TextFilter)
 
 
 def compile_to_django(search):
@@ -50,8 +47,12 @@ def compile_q_objects(search):
 
 class DjangoCompiler(ICompiler):
     # directive, regexpr, and text all return a list of Qsets
+
     def directive(self, directive, value):
         return DirectiveFilter(directive, value).compile_Q()
+
+    def mac_addr(self, addr):
+        return MacAddressFilter(addr).compile_Q()
 
     def regexpr(self, reg_expr):
         return REFilter(reg_expr).compile_Q()

--- a/cyder/search/compiler/dsl.py
+++ b/cyder/search/compiler/dsl.py
@@ -1,18 +1,17 @@
-from parsley import wrapGrammar
-
 from ometa.grammar import OMeta
 from ometa.runtime import OMetaBase
+from parsley import wrapGrammar
 
-from cyder.search.compiler.invparsley import grammar
 
-name = 'CyDSL'
-B = OMeta.makeGrammar(grammar, name=name).createParserClass(
-    OMetaBase, globals()
-)
+with open('cyder/search/compiler/search.parsley') as g:
+    B = OMeta.makeGrammar(g.read()).createParserClass(OMetaBase, globals())
 
 
 class ICompiler(B):
     def directive(self, d, v):
+        raise NotImplemented()
+
+    def mac_addr(self, addr):
         raise NotImplemented()
 
     def regexpr(self, r):
@@ -38,6 +37,9 @@ class DebugCompiler(ICompiler):
     def directive(self, d, v):
         return d, v
 
+    def mac_addr(self, addr):
+        return '[' + addr + ']'
+
     def regexpr(self, r):
         return r
 
@@ -51,13 +53,13 @@ class DebugCompiler(ICompiler):
         return ret
 
     def OR_op(self):
-        return lambda a, b: '({0} {1} {2})'.format(a, 'OR', b)
+        return lambda a, b: '({} OR {})'.format(a, b)
 
     def AND_op(self):
-        return lambda a, b: '({0} {1} {2})'.format(a, 'AND', b)
+        return lambda a, b: '({} AND {})'.format(a, b)
 
     def NOT_op(self):
-        return lambda a: '({0} {1})'.format('NOT', a)
+        return lambda a: '(NOT {})'.format(a)
 
 
 def make_debug_compiler():

--- a/cyder/search/compiler/invfilter.py
+++ b/cyder/search/compiler/invfilter.py
@@ -59,21 +59,29 @@ class _Filter(object):
     def __str__(self):
         return self.value
 
-    def __repr__(self):
-        return "<{1}>".format(self.__class__, self)
-
     def compile_Q(self, ntype):
         pass
 
 
 def build_filter(filter_, fields, filter_type):
-    # rtucker++
     final_filter = Q()
     for t in fields:
         final_filter = final_filter | Q(**{"{0}__{1}".format(
             t, filter_type): filter_})
 
     return final_filter
+
+
+class MacAddressFilter(_Filter):
+    def __init__(self, addr):
+        self.addr = addr
+
+    def compile_Q(self):
+        result = []
+        for name, Klass in searchables:
+            result.append(
+                Q(mac=self.addr) if name in ('STATIC', 'DYNAMIC') else None)
+        return result
 
 
 class TextFilter(_Filter):
@@ -143,10 +151,11 @@ class DirectiveFilter(_Filter):
             )
 
 
-# TODO, move this into it's own file
+# TODO: move this into its own file
 ##############################################################################
 ##########################  Directive Filters  ###############################
 ##############################################################################
+
 
 class BadDirective(Exception):
     pass
@@ -221,7 +230,7 @@ def build_range_qsets(range_):
 
 
 def build_network_qsets(network_str):
-    # Todo move these directive processors into functions.
+    # TODO: move these directive processors into functions.
     if network_str.find(':') > -1:
         Klass = ipaddr.IPv6Network
         ip_type = '6'

--- a/cyder/search/compiler/search.parsley
+++ b/cyder/search/compiler/search.parsley
@@ -1,4 +1,3 @@
-grammar = """
 # DSL for Cyder
 # Grammar base classes should implement the following functions:
 # - directive
@@ -9,53 +8,62 @@ grammar = """
 # - NOT_op
 # - compile
 
-ws = ' '*
 wss = ' '+
-not_ws = :c ?(c not in (' ', '\t')) -> c
-letter = :c ?('a' <= c <= 'z' or 'A' <= c <= 'Z') -> c
+not_ws = anything:c ?(c not in ' \t') -> c
 special = '_' | '.' | '-' | ':' | ','
+hex_digit =
+    anything:c ?('0' <= c <= '9' or 'a' <= c <= 'f' or 'A' <= c <= 'F')
+        -> c
+
 
 # Lexical Operators
 NOT = '!'
-AND = <letter+>:and_ ?(and_ == 'AND') -> self.AND_op()
-OR = <letter+>:or_ ?(or_ == 'OR') -> self.OR_op()
+AND = 'AND' -> self.AND_op()
+OR = 'OR' -> self.OR_op()
+
+# MAC address
+MAC_ADDR =
+    (
+        <(hex_digit{2} ':'){5} hex_digit{2}> |
+        <(hex_digit{2} '-'){5} hex_digit{2}> |
+        <hex_digit{12}>
+    ):addr ~not_ws
+        -> self.mac_addr(addr)
 
 # Directive
-EQ = ':'
-d_lhs = letter | '_'
+d_lhs = 'view' | 'network' | 'vlan' | 'zone' | 'range' | 'type' | 'site'
 d_rhs = letterOrDigit | special | '/'
-DRCT = <d_lhs+>:d EQ <d_rhs+>:v -> self.directive(d, v)
+DRCT = <d_lhs>:d ':' <d_rhs+>:v -> self.directive(d, v)
 
 # Regular Expression
 RE = '/' <(not_ws)+>:r -> self.regexpr(r)
 
 # Regular text
-text = (~OR ~AND ~NOT <(letterOrDigit | special )+>:t) -> t
+text = (~OR ~AND ~NOT <(letterOrDigit | special)+>:t) -> t
 TEXT = <text+>:t -> self.text(t)
 
 
 # DSF (Device Specific Filters)
-DSF = DRCT | RE | TEXT
+DSF = MAC_ADDR | DRCT | RE | TEXT
 
-# An atmon
+# An atom
 atom = DSF | parens
 
-value = NOT ws atom:a -> self.NOT_op()(a)
-| atom
+value = (NOT ws atom:a -> self.NOT_op()(a)) | atom
 
 # Parens
 parens = '(' ws expr:e ws ')' -> e
 
 # Operators Precidence
 # 1) i_and
-# 2) 2_and
+# 2) e_and
 # 3) e_or
 
 # x AND y <-- Explicit AND
 e_and = AND:op wss value:v -> (op, v)
 
 # x y <-- Implicit AND
-i_and = (' '+ ~OR ~AND) value:v -> (self.AND_op(), v)
+i_and = (wss ~OR ~AND) value:v -> (self.AND_op(), v)
 
 # x OR y <-- Explicit OR
 e_or = OR:op wss expr_2:v -> (op, v)
@@ -65,4 +73,3 @@ e_or = OR:op wss expr_2:v -> (op, v)
 expr = expr_2:left ws e_or*:right -> self.compile(left, right)
 expr_2 = expr_3:left ws e_and*:right -> self.compile(left, right)
 expr_3 = value:left i_and*:right -> self.compile(left, right)
-"""

--- a/cyder/search/tests/test_parser.py
+++ b/cyder/search/tests/test_parser.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from ometa.runtime import ParseError
 
-from cyder.search.compiler.invdsl import make_debug_compiler
+from cyder.search.compiler.dsl import make_debug_compiler
 
 
 class T(TestCase):
@@ -19,20 +19,20 @@ class DRCTTest(T):
     rule = 'DRCT'
 
     def test1(self):
-        self.assertEqual(('foo', 'bar'), self.parse('foo:bar'))
+        self.assertEqual(('foo', 'bar'), self.parse('site:bar'))
 
     def test2(self):
-        lhs = 'foo'
+        lhs = 'view'
         rhs = '-df:,832kjda_'
         self.assertEqual((lhs, rhs), self.parse('{0}:{1}'.format(lhs, rhs)))
 
     def test3(self):
-        lhs = 'foo'
+        lhs = 'zone'
         rhs = '-=df:,832kjda_'
         self.fail('{0}:{1}'.format(lhs, rhs))
 
     def test4(self):
-        self.fail('foo')
+        self.fail('zone')
 
 
 class TextTest(T):

--- a/cyder/search/views.py
+++ b/cyder/search/views.py
@@ -32,8 +32,7 @@ def search(request):
 
 
 def _search(request):
-    search = request_to_search(request).split(' ')
-    search = ' '.join([strip_if_mac_with_colons(word) for word in search])
+    search = request_to_search(request)
 
     objs, error_resp = compile_to_django(search)
     if not objs:

--- a/cyder/templates/search/search_help.html
+++ b/cyder/templates/search/search_help.html
@@ -37,18 +37,6 @@
           </p>
         </td>
       </tr>
-      <tr>
-        <td id="sub-header">
-          '..'
-        </td>
-        <td>
-          <p>
-          When you surround '..' with numbers, inventory will expand your query into multiple
-          queries. For example: A search for <code>web1..3</code> is understood to be a search for
-          <code>web1</code> <b>OR</b> <code>web2</code> <b>OR</b> <code>web3</code>.
-          </p>
-        </td>
-      </tr>
     </table>
     <table border="0" cellspacing="10">
       <h2><u>Operators</u></h2>


### PR DESCRIPTION
**Resolves issue #958.**

Searching for a MAC address is now case-insensitive regardless of whether it's delimited by colons or hyphens or undelimited.