### PR TITLE
Unicode search fix

### DIFF
--- a/cyder/search/compiler/django_compile.py
+++ b/cyder/search/compiler/django_compile.py
@@ -42,7 +42,7 @@ def compile_q_objects(search):
         qs = compiler(search).expr()
         return qs, None
     except (BadDirective, ParseError) as why:
-        return None, str(why)
+        return None, why.formatReason()
 
 
 class DjangoCompiler(ICompiler):


### PR DESCRIPTION
**Resolves the issue seen recently in which searching for a square root symbol ("√") causes a server error.**

The problem was that either OMeta or Parsley doesn't correctly format parsing exception messages, and trying to stringify them causes a UnicodeDecodeError. This pull request works around the bug by changing the way we stringify parsing exceptions so that it can never raise a UnicodeDecodeError.