### PR TITLE
Add range comment to pool decls in dhcpd_compare2 output

### DIFF
--- a/cyder/management/commands/lib/dhcpd_compare2/dhcp_objects.py
+++ b/cyder/management/commands/lib/dhcpd_compare2/dhcp_objects.py
@@ -90,6 +90,7 @@ class Pool(DHCPMixin):
 
         rs = next(ifilter(is_rangestmt, contents))
         self.start, self.end = rs.start, rs.end
+        self.comment = '{} - {}'.format(self.start, self.end)
 
     def set_sort_key(self):
         self._sort_key = (int(IPAddress(self.start)),


### PR DESCRIPTION
**Resolves issue #988.**

This one's pretty trivial. The diff used to look like this:

```none
 subnet 10.0.0.0 netmask 255.0.0.0 {
      pool {
          +option routers 10.2.0.1;
      }
 }
 subnet 192.168.0.0 netmask 255.255.0.0 {
     -pool {
     -    range 192.168.2.2 192.168.5.254;
     -}
 }
```

Now it looks like this:

```none
 subnet 10.0.0.0 netmask 255.0.0.0 {
      pool { # 10.2.0.2 - 10.2.255.254
          +option routers 10.2.0.1;
      }
 }
 subnet 192.168.0.0 netmask 255.255.0.0 {
     -pool { # 192.168.2.2 - 192.168.5.254
     -    range 192.168.2.2 192.168.5.254;
     -}
 }
```

It's redundant for pools that are added or removed, because you can see the `range` parameter itself, but it still might help if a pool has more than a few lines.