### PR TITLE
Check objects before removing them from containers

### DIFF
--- a/cyder/base/constants.py
+++ b/cyder/base/constants.py
@@ -38,7 +38,7 @@ DNS_OBJECTS = ("address_record", "cname", "domain", "mx", "nameserver", "ptr",
 CORE_OBJECTS = ("ctnr_users", "ctnr", "user", "system")
 
 
-def get_klasses(obj_type):
+def get_klasses(obj_type=None):
     from cyder.cydns.address_record.forms import AddressRecordForm
     from cyder.cydns.cname.forms import CNAMEForm
     from cyder.core.ctnr.forms import CtnrForm
@@ -66,7 +66,6 @@ def get_klasses(obj_type):
         SSHFP, StaticInterface, System, SystemAV, TXT, Vlan, VlanAV, Vrf,
         VrfAV, Workgroup, WorkgroupAV
     )
-
 
     klasses = {
         'address_record': (AddressRecord, AddressRecordForm),
@@ -98,5 +97,8 @@ def get_klasses(obj_type):
         'workgroup': (Workgroup, WorkgroupForm),
         'workgroup_av': (WorkgroupAV, WorkgroupAVForm),
     }
+
+    if obj_type is None:
+        return klasses.values()
 
     return klasses[obj_type]

--- a/cyder/core/ctnr/models.py
+++ b/cyder/core/ctnr/models.py
@@ -157,7 +157,6 @@ def objects_removed(ctnr, objects, objtype="domain"):
                     except FieldError:
                         continue
                     results = results.filter(**kwargs)
-                    assert bool(results) == results.exists()
 
                 if results:
                     raise ValidationError(

--- a/cyder/core/ctnr/views.py
+++ b/cyder/core/ctnr/views.py
@@ -3,6 +3,7 @@ import json
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.core.exceptions import ValidationError
 from django.forms import ChoiceField, HiddenInput
 from django.http import HttpResponse
 from django.shortcuts import redirect
@@ -257,8 +258,11 @@ def remove_object(request, ctnr_pk):
 
         else:
             if obj in m2m.all():
-                m2m.remove(obj)
-                return_status['success'] = True
+                try:
+                    m2m.remove(obj)
+                    return_status['success'] = True
+                except ValidationError, e:
+                    return_status['error'] = "; ".join(e.messages)
             else:
                 return_status['error'] = (
                     '{0} does not exist in {1}'.format(str(obj), ctnr))

--- a/cyder/cydns/address_record/models.py
+++ b/cyder/cydns/address_record/models.py
@@ -29,14 +29,6 @@ class BaseAddressRecord(Ip, LabelDomainMixin, CydnsRecord):
         return u'{} {} {}'.format(self.fqdn, self.rdtype, self.ip_str)
 
     @property
-    def actual_ctnr(self):
-        from cyder.cydhcp.interface.static_intr.models import StaticInterface
-        if isinstance(self, StaticInterface):
-            return self.system.ctnr
-        else:
-            return self.ctnr
-
-    @property
     def rdtype(self):
         if self.ip_type == IP_TYPE_6:
             return 'AAAA'
@@ -92,7 +84,7 @@ class BaseAddressRecord(Ip, LabelDomainMixin, CydnsRecord):
         from cyder.cydhcp.interface.static_intr.models import StaticInterface
         assert self.fqdn
         try:
-            self.actual_ctnr
+            self.ctnr
         except Ctnr.DoesNotExist:
             # By this point, Django will already have encountered a
             # Validation error about the ctnr field, so there's no need to
@@ -100,9 +92,9 @@ class BaseAddressRecord(Ip, LabelDomainMixin, CydnsRecord):
             return
 
         ars = (AddressRecord.objects.filter(fqdn=self.fqdn)
-                                    .exclude(ctnr=self.actual_ctnr))
+                                    .exclude(ctnr=self.ctnr))
         sis = (StaticInterface.objects.filter(fqdn=self.fqdn)
-                                      .exclude(system__ctnr=self.actual_ctnr))
+                                      .exclude(system__ctnr=self.ctnr))
 
         if isinstance(self, AddressRecord):
             ars = ars.exclude(pk=self.pk)


### PR DESCRIPTION
This is intended to prevent situations where, given an object with a matching container field and domain/range/workgroup field, if the domain/range/workgroup is removed from the container, a validation error will be raised so that an invalid object will not be left behind.
Resolves https://github.com/OSU-Net/cyder/issues/987