### PR TITLE
Issue #1012 Regex filter support in API

### DIFF
--- a/cyder/api/v1/filter.py
+++ b/cyder/api/v1/filter.py
@@ -42,10 +42,7 @@ class SearchFieldFilter(filters.BaseFilterBackend):
 
         for q in request.QUERY_PARAMS:
             p = request.QUERY_PARAMS[q]
-            if q.endswith(("__regex", "__iregex")):
-                continue
-
-            elif q.startswith("i:"):
+            if q.startswith("i:"):
                 q_include[namehack(q[2:])] = p
 
             elif q.startswith("e:"):


### PR DESCRIPTION
Enable regex filtering in the API.

Theoretically this should work, since the only thing stopping regexes before was the `if q.endswidth(("__regex", "__iregex"))` check. Haven't tested it at all, though.