### PR TITLE
Don't auto add objects to containers

### DIFF
--- a/cyder/base/mixins.py
+++ b/cyder/base/mixins.py
@@ -104,10 +104,13 @@ class UsabilityFormMixin(object):
                 self.fields[fieldname].queryset = field.queryset.order_by(
                     *field.queryset.model.sort_fields)
 
-    def filter_by_ctnr_all(self, request):
+    def filter_by_ctnr_all(self, request, skip=None):
         from cyder.core.ctnr.models import Ctnr
         ctnr = request.session['ctnr']
         for fieldname, field in self.fields.items():
+            if skip and fieldname in skip:
+                continue
+
             if not hasattr(field, 'queryset'):
                 continue
 

--- a/cyder/base/views.py
+++ b/cyder/base/views.py
@@ -158,10 +158,6 @@ def cy_view(request, template, pk=None, obj_type=None):
                     if Klass.__name__ == 'Ctnr':
                         request = ctnr_update_session(request, obj)
 
-                    if (hasattr(obj, 'ctnr_set') and
-                            not obj.ctnr_set.exists()):
-                        obj.ctnr_set.add(request.session['ctnr'])
-
                     object_table = tablefy([obj], request=request)
                     return HttpResponse(
                         json.dumps({'row': object_table}))

--- a/cyder/cydhcp/range/forms.py
+++ b/cyder/cydhcp/range/forms.py
@@ -27,6 +27,8 @@ class RangeForm(ViewChoiceForm, UsabilityFormMixin):
 
         self.fields['network'].widget.attrs.update({'class': 'networkWizard'})
 
+    def filter_by_ctnr_all(self, ctnr):
+        super(RangeForm, self).filter_by_ctnr_all(ctnr, skip='network')
 
 
 RangeAVForm = get_eav_form(RangeAV, Range)


### PR DESCRIPTION
This pull request does two things.

1. Objects are no longer automatically added to the current container when they are created.
2. The network list on the range create form shows all networks instead of only those associated with the current container.

Note that the 1st change is general and the 2nd change is specific. For 1, I could have instead only prevented Ranges from being automatically added. For 2, I could shown the full list in all forms for any object that doesn't have an explicit `ctnr` or `ctnr_set` field. But I chose this approach because it seemed the safest and most reasonable. If necessary, I can change it to the other approach.