### PR TITLE
Make static interfaces and address records conflict properly

### DIFF
--- a/cyder/cydhcp/interface/static_intr/models.py
+++ b/cyder/cydhcp/interface/static_intr/models.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 
 from django.db import models
+from django.db.models import Q
 from django.core.exceptions import ValidationError
 
 import datetime
@@ -216,12 +217,11 @@ class StaticInterface(BaseAddressRecord, BasePTR, ExpirableMixin):
                                       "not in its container." % self.ip_str)
 
         from cyder.cydns.ptr.models import PTR
-        if PTR.objects.filter(ip_str=self.ip_str, fqdn=self.fqdn).exists():
-            raise ValidationError("A PTR already uses '%s' and '%s'" %
-                                  (self.fqdn, self.ip_str))
-        if AddressRecord.objects.filter(ip_str=self.ip_str, fqdn=self.fqdn
-                                        ).exists():
-            raise ValidationError("An A record already uses '%s' and '%s'" %
+        if PTR.objects.filter(ip_str=self.ip_str).exists():
+            raise ValidationError("A PTR already uses '%s'." % self.ip_str)
+        if AddressRecord.objects.filter(
+                Q(ip_str=self.ip_str) | Q(fqdn=self.fqdn)).exists():
+            raise ValidationError("An A record already uses '%s' or '%s'" %
                                   (self.fqdn, self.ip_str))
 
         if validate_glue:

--- a/cyder/cydhcp/interface/static_intr/tests/A_tests.py
+++ b/cyder/cydhcp/interface/static_intr/tests/A_tests.py
@@ -7,14 +7,13 @@ from .basestatic import BaseStaticTests
 class AStaticRegTests(BaseStaticTests):
     def test_conflict(self):
         # Add an intr and make sure A can't exist.
-        label = "foo4"
         domain = self.f_c
         ip_str = "10.0.0.2"
 
         def i():
             return self.create_si(
                 mac="11:22:33:44:55:66",
-                label=label,
+                label="foo4",
                 domain=domain,
                 ip_str=ip_str,
             )
@@ -22,7 +21,7 @@ class AStaticRegTests(BaseStaticTests):
 
         def a():
             return AddressRecord.objects.create(
-                label=label,
+                label="foo5",
                 domain=domain,
                 ip_str=ip_str,
                 ctnr=self.ctnr,

--- a/cyder/cydhcp/interface/static_intr/tests/A_tests.py
+++ b/cyder/cydhcp/interface/static_intr/tests/A_tests.py
@@ -32,18 +32,17 @@ class AStaticRegTests(BaseStaticTests):
 
     def test_conflict_add_intr_first(self):
         # Add an intr and update an existing A to conflict. Test for exception.
-        label = "fo99"
         domain = self.f_c
 
         self.create_si(
             mac="12:22:33:44:55:66",
-            label=label,
+            label="fo99",
             domain=domain,
             ip_str='10.0.0.2',
         )
 
         a = AddressRecord.objects.create(
-            label=label,
+            label="fo999",
             domain=domain,
             ip_str='10.0.0.3',
             ctnr=self.ctnr,
@@ -55,11 +54,10 @@ class AStaticRegTests(BaseStaticTests):
     def test_conflict_add_A_first(self):
         # Add an A and update and existing intr to conflict. Test for
         # exception.
-        label = "foo98"
         domain = self.f_c
 
         AddressRecord.objects.create(
-            label=label,
+            label="foo98",
             domain=domain,
             ip_str='10.0.0.2',
             ctnr=self.ctnr,
@@ -67,7 +65,7 @@ class AStaticRegTests(BaseStaticTests):
 
         intr = self.create_si(
             mac="11:22:33:44:55:66",
-            label=label,
+            label="foo987",
             domain=domain,
             ip_str='10.0.0.3',
         )

--- a/cyder/cydns/address_record/tests/test_models.py
+++ b/cyder/cydns/address_record/tests/test_models.py
@@ -628,8 +628,7 @@ class AddressRecordTests(DNSTest, ModelTestMixin):
         self.assertObjectsConflict((create_cname, create_ar))
 
     def test_same_name_as_static_interface(self):
-        """Test that ARs and SIs can share a name iff they have the same ctnr
-        """
+        """Test that ARs and SIs cannot share a name"""
         n = Network.objects.create(
             vrf=Vrf.objects.get(name='test_vrf'), network_str='128.193.0.0/24',
             ip_type='4')
@@ -663,7 +662,7 @@ class AddressRecordTests(DNSTest, ModelTestMixin):
                 label='foo1', domain=self.o_e, ip_str='128.193.0.3', ctnr=c2)
         create_ar_different_ctnr.name = 'AddressRecord with different ctnr'
 
-        self.assertObjectsDontConflict((create_si, create_ar_same_ctnr))
+        self.assertObjectsConflict((create_si, create_ar_same_ctnr))
         self.assertObjectsConflict((create_si, create_ar_different_ctnr))
 
     def test_target_validation(self):

--- a/cyder/cydns/nameserver/tests/test_models.py
+++ b/cyder/cydns/nameserver/tests/test_models.py
@@ -133,10 +133,9 @@ class NSTestsModels(DNSTest, ModelTestMixin):
     def test_manual_assign_of_glue(self):
         # Test that assigning a different glue record doesn't get overriden by
         # the auto assinging during the Nameserver's clean function.
-        glue = StaticInterface.objects.create(
-            label='ns25', domain=self.f_r,
-            ip_str='128.193.99.10', ip_type='4', system=self.s,
-            mac="11:22:33:44:55:66")
+        glue = AddressRecord.objects.create(
+            label='ns25', ctnr=self.ctnr, domain=self.f_r,
+            ip_str='128.193.99.10', ip_type='4')
         ns = Nameserver.objects.create(domain=self.f_r, server='ns25.foo.ru')
         self.assertTrue(ns.glue)
         self.assertEqual(ns.glue, glue)


### PR DESCRIPTION
Resolves https://github.com/OSU-Net/cyder/issues/1026

Previously we allowed static interfaces and address records to share a name if they also shared a container, and did not share an IP address, but this specification has changed.